### PR TITLE
Feature/local node message optimization

### DIFF
--- a/node/assignment.go
+++ b/node/assignment.go
@@ -15,7 +15,6 @@ func (n *Node) assignment(pid string, item goarSchema.BundleItem) (assign hymxSc
 	msg, _ := n.db.GetMessage(item.Id)
 	if msg != nil {
 		err = schema.ErrDuplicateItem
-		n.sendAssignmentResult(pid, item, assign, assignItem, err)
 		return
 	}
 
@@ -23,7 +22,6 @@ func (n *Node) assignment(pid string, item goarSchema.BundleItem) (assign hymxSc
 	nonce, err = n.db.GetNonce(pid)
 	if err != nil {
 		log.Error("assignment get nonce failed", "pid", pid, "err", err)
-		n.sendAssignmentResult(pid, item, assign, assignItem, err)
 		return
 	}
 	nonce = nonce + 1
@@ -31,19 +29,14 @@ func (n *Node) assignment(pid string, item goarSchema.BundleItem) (assign hymxSc
 	assign, assignItem, err = n.signAssign(pid, item.Id, nonce)
 	if err != nil {
 		log.Error("assignment sign assign failed", "pid", pid, "err", err)
-		n.sendAssignmentResult(pid, item, assign, assignItem, err)
 		return
 	}
 
 	err = n.db.Commit(pid, nonce, item, assignItem)
 	if err != nil {
 		log.Error("assignment commit failed", "pid", pid, "err", err)
-		n.sendAssignmentResult(pid, item, assign, assignItem, err)
 		return
 	}
-
-	// send assignment success message to channel
-	n.sendAssignmentResult(pid, item, assign, assignItem, nil)
 
 	return
 }

--- a/node/assignment.go
+++ b/node/assignment.go
@@ -11,9 +11,11 @@ import (
 )
 
 func (n *Node) assignment(pid string, item goarSchema.BundleItem) (assign hymxSchema.Assignment, assignItem goarSchema.BundleItem, err error) {
+
 	msg, _ := n.db.GetMessage(item.Id)
 	if msg != nil {
 		err = schema.ErrDuplicateItem
+		n.sendAssignmentResult(pid, item.Id, assign, assignItem, err)
 		return
 	}
 
@@ -21,6 +23,7 @@ func (n *Node) assignment(pid string, item goarSchema.BundleItem) (assign hymxSc
 	nonce, err = n.db.GetNonce(pid)
 	if err != nil {
 		log.Error("assignment get nonce failed", "pid", pid, "err", err)
+		n.sendAssignmentResult(pid, item.Id, assign, assignItem, err)
 		return
 	}
 	nonce = nonce + 1
@@ -28,14 +31,20 @@ func (n *Node) assignment(pid string, item goarSchema.BundleItem) (assign hymxSc
 	assign, assignItem, err = n.signAssign(pid, item.Id, nonce)
 	if err != nil {
 		log.Error("assignment sign assign failed", "pid", pid, "err", err)
+		n.sendAssignmentResult(pid, item.Id, assign, assignItem, err)
 		return
 	}
 
 	err = n.db.Commit(pid, nonce, item, assignItem)
 	if err != nil {
 		log.Error("assignment commit failed", "pid", pid, "err", err)
+		n.sendAssignmentResult(pid, item.Id, assign, assignItem, err)
 		return
 	}
+
+	// send assignment success message to channel
+	n.sendAssignmentResult(pid, item.Id, assign, assignItem, nil)
+
 	return
 }
 
@@ -53,4 +62,28 @@ func (n *Node) signAssign(pid, msgid string, nonce int64) (assign hymxSchema.Ass
 	}
 	assignItem, err = n.bundler.CreateAndSignItem([]byte{}, "", "", tags)
 	return
+}
+
+// sendAssignmentResult send assignment result to channel
+func (n *Node) sendAssignmentResult(pid, itemId string, assign hymxSchema.Assignment, assignItem goarSchema.BundleItem, err error) {
+	assignmentResult := schema.AssignmentResult{
+		Assign:     assign,
+		AssignItem: assignItem,
+		Error:      err,
+		Pid:        pid,
+		ItemId:     itemId,
+	}
+
+	n.outboxAssignmentMu.RLock()
+	resultChan, exists := n.outboxAssignmentChans[itemId]
+	n.outboxAssignmentMu.RUnlock()
+
+	if exists {
+		select {
+		case resultChan <- assignmentResult:
+
+		default:
+			log.Warn("Failed to send assignment result to outbox channel", "itemId", itemId)
+		}
+	}
 }

--- a/node/assignment.go
+++ b/node/assignment.go
@@ -59,13 +59,11 @@ func (n *Node) signAssign(pid, msgid string, nonce int64) (assign hymxSchema.Ass
 
 // sendAssignmentResult send assignment result to channel
 func (n *Node) sendAssignmentResult(pid string, item goarSchema.BundleItem, assign hymxSchema.Assignment, assignItem goarSchema.BundleItem, err error) {
-	assignmentResult := schema.AssignmentResult{
+	n.assignmentChan <- schema.AssignmentResult{
 		Pid:        pid,
 		Item:       item,
 		Assign:     assign,
 		AssignItem: assignItem,
 		Error:      err,
 	}
-
-	n.assignmentChan <- assignmentResult
 }

--- a/node/assignment.go
+++ b/node/assignment.go
@@ -56,14 +56,3 @@ func (n *Node) signAssign(pid, msgid string, nonce int64) (assign hymxSchema.Ass
 	assignItem, err = n.bundler.CreateAndSignItem([]byte{}, "", "", tags)
 	return
 }
-
-// sendAssignmentResult send assignment result to channel
-func (n *Node) sendAssignmentResult(pid string, item goarSchema.BundleItem, assign hymxSchema.Assignment, assignItem goarSchema.BundleItem, err error) {
-	n.assignmentChan <- schema.AssignmentResult{
-		Pid:        pid,
-		Item:       item,
-		Assign:     assign,
-		AssignItem: assignItem,
-		Error:      err,
-	}
-}

--- a/node/assignment.go
+++ b/node/assignment.go
@@ -15,7 +15,7 @@ func (n *Node) assignment(pid string, item goarSchema.BundleItem) (assign hymxSc
 	msg, _ := n.db.GetMessage(item.Id)
 	if msg != nil {
 		err = schema.ErrDuplicateItem
-		n.sendAssignmentResult(pid, item.Id, assign, assignItem, err)
+		n.sendAssignmentResult(pid, item, assign, assignItem, err)
 		return
 	}
 
@@ -23,7 +23,7 @@ func (n *Node) assignment(pid string, item goarSchema.BundleItem) (assign hymxSc
 	nonce, err = n.db.GetNonce(pid)
 	if err != nil {
 		log.Error("assignment get nonce failed", "pid", pid, "err", err)
-		n.sendAssignmentResult(pid, item.Id, assign, assignItem, err)
+		n.sendAssignmentResult(pid, item, assign, assignItem, err)
 		return
 	}
 	nonce = nonce + 1
@@ -31,19 +31,19 @@ func (n *Node) assignment(pid string, item goarSchema.BundleItem) (assign hymxSc
 	assign, assignItem, err = n.signAssign(pid, item.Id, nonce)
 	if err != nil {
 		log.Error("assignment sign assign failed", "pid", pid, "err", err)
-		n.sendAssignmentResult(pid, item.Id, assign, assignItem, err)
+		n.sendAssignmentResult(pid, item, assign, assignItem, err)
 		return
 	}
 
 	err = n.db.Commit(pid, nonce, item, assignItem)
 	if err != nil {
 		log.Error("assignment commit failed", "pid", pid, "err", err)
-		n.sendAssignmentResult(pid, item.Id, assign, assignItem, err)
+		n.sendAssignmentResult(pid, item, assign, assignItem, err)
 		return
 	}
 
 	// send assignment success message to channel
-	n.sendAssignmentResult(pid, item.Id, assign, assignItem, nil)
+	n.sendAssignmentResult(pid, item, assign, assignItem, nil)
 
 	return
 }
@@ -65,19 +65,14 @@ func (n *Node) signAssign(pid, msgid string, nonce int64) (assign hymxSchema.Ass
 }
 
 // sendAssignmentResult send assignment result to channel
-func (n *Node) sendAssignmentResult(pid, itemId string, assign hymxSchema.Assignment, assignItem goarSchema.BundleItem, err error) {
+func (n *Node) sendAssignmentResult(pid string, item goarSchema.BundleItem, assign hymxSchema.Assignment, assignItem goarSchema.BundleItem, err error) {
 	assignmentResult := schema.AssignmentResult{
+		Pid:        pid,
+		Item:       item,
 		Assign:     assign,
 		AssignItem: assignItem,
 		Error:      err,
-		Pid:        pid,
-		ItemId:     itemId,
 	}
 
-	select {
-	case n.assignmentChan <- assignmentResult:
-		// send success to channel
-	default:
-		//
-	}
+	n.assignmentChan <- assignmentResult
 }

--- a/node/assignment.go
+++ b/node/assignment.go
@@ -74,16 +74,10 @@ func (n *Node) sendAssignmentResult(pid, itemId string, assign hymxSchema.Assign
 		ItemId:     itemId,
 	}
 
-	n.outboxAssignmentMu.RLock()
-	resultChan, exists := n.outboxAssignmentChans[itemId]
-	n.outboxAssignmentMu.RUnlock()
-
-	if exists {
-		select {
-		case resultChan <- assignmentResult:
-
-		default:
-			log.Warn("Failed to send assignment result to outbox channel", "itemId", itemId)
-		}
+	select {
+	case n.assignmentChan <- assignmentResult:
+		// send success to channel
+	default:
+		//
 	}
 }

--- a/node/channel.go
+++ b/node/channel.go
@@ -98,7 +98,7 @@ func (n *Node) runAssignmentChan() {
 			return
 
 		case assignmentResult := <-n.assignmentChan:
-			log.Debug("assign chan get notice", "msgid", assignmentResult.ItemId)
+			log.Debug("assign chan get notice", "msgid", assignmentResult.Item.Id)
 
 			// handle assignment success
 			n.assignmentHandlerLockMu.RLock()

--- a/node/channel.go
+++ b/node/channel.go
@@ -3,6 +3,8 @@ package node
 import (
 	"fmt"
 	"time"
+
+	"github.com/hymatrix/hymx/node/schema"
 )
 
 func (n *Node) runMsgChan() {
@@ -17,7 +19,13 @@ func (n *Node) runMsgChan() {
 		case i := <-n.assignMesChan:
 
 			assign, assignItem, err := n.assignment(i.Pid, i.Item)
-			n.sendAssignmentResult(i.Pid, i.Item, assign, assignItem, err)
+			n.assignmentChan <- schema.AssignmentResult{
+				Pid:        i.Pid,
+				Item:       i.Item,
+				Assign:     assign,
+				AssignItem: assignItem,
+				Error:      err,
+			}
 			if err != nil {
 				log.Error("assignment failed", "pid", i.Pid, "itemId", i.Item.Id, "err", err)
 				continue
@@ -48,7 +56,13 @@ func (n *Node) runProcChan() {
 			}
 
 			assign, assignItem, err := n.assignment(i.Pid, i.Item)
-			n.sendAssignmentResult(i.Pid, i.Item, assign, assignItem, err)
+			n.assignmentChan <- schema.AssignmentResult{
+				Pid:        i.Pid,
+				Item:       i.Item,
+				Assign:     assign,
+				AssignItem: assignItem,
+				Error:      err,
+			}
 			if err != nil {
 				log.Error("assignment failed", "pid", i.Pid, "itemId", i.Item.Id, "err", err)
 			}

--- a/node/channel.go
+++ b/node/channel.go
@@ -89,6 +89,27 @@ func (n *Node) runResultChan() {
 	}
 }
 
+func (n *Node) runAssignmentChan() {
+	n.wg.Add(1)
+	defer n.wg.Done()
+	for {
+		select {
+		case <-n.ctx.Done():
+			return
+
+		case assignmentResult := <-n.assignmentChan:
+			log.Debug("assign chan get notice", "msgid", assignmentResult.ItemId)
+
+			// handle assignment success
+			n.assignmentHandlerLockMu.RLock()
+			for _, handler := range n.assignmentHandlers {
+				handler(assignmentResult)
+			}
+			n.assignmentHandlerLockMu.RUnlock()
+		}
+	}
+}
+
 func (n *Node) runOutboxChan() {
 	n.wg.Add(1)
 	defer n.wg.Done()

--- a/node/channel.go
+++ b/node/channel.go
@@ -16,7 +16,8 @@ func (n *Node) runMsgChan() {
 
 		case i := <-n.assignMesChan:
 
-			assign, _, err := n.assignment(i.Pid, i.Item)
+			assign, assignItem, err := n.assignment(i.Pid, i.Item)
+			n.sendAssignmentResult(i.Pid, i.Item, assign, assignItem, err)
 			if err != nil {
 				log.Error("assignment failed", "pid", i.Pid, "itemId", i.Item.Id, "err", err)
 				continue
@@ -46,7 +47,9 @@ func (n *Node) runProcChan() {
 				continue
 			}
 
-			if _, _, err := n.assignment(i.Pid, i.Item); err != nil {
+			assign, assignItem, err := n.assignment(i.Pid, i.Item)
+			n.sendAssignmentResult(i.Pid, i.Item, assign, assignItem, err)
+			if err != nil {
 				log.Error("assignment failed", "pid", i.Pid, "itemId", i.Item.Id, "err", err)
 			}
 

--- a/node/handle.go
+++ b/node/handle.go
@@ -151,6 +151,7 @@ func (n *Node) authNode(accid, fromProcess string) (err error) {
 		}
 	}
 	if !validNode {
+		log.Error("auth node failed", "accid", accid, "fromProcess", fromProcess)
 		return schema.ErrUnauthorizedNode
 	}
 

--- a/node/node.go
+++ b/node/node.go
@@ -45,6 +45,10 @@ type Node struct {
 	outboxSendingLock map[string]bool
 	outboxLockMu      sync.RWMutex
 
+	// outbox assignment result channels
+	outboxAssignmentChans map[string]chan schema.AssignmentResult
+	outboxAssignmentMu    sync.RWMutex
+
 	db       schema.IDB
 	outboxDB schema.IDBOutbox
 
@@ -84,6 +88,8 @@ func New(
 
 		outboxChan:        outboxChan,
 		outboxSendingLock: map[string]bool{},
+
+		outboxAssignmentChans: map[string]chan schema.AssignmentResult{},
 
 		db:               rdb.New(redisURL),
 		outboxDB:         cache.NewOutbox(),
@@ -200,4 +206,13 @@ func (n *Node) AddResultHandler(handler ...schema.ResultHandler) {
 	defer n.resultHandlerLockMu.Unlock()
 
 	n.resultHandlers = append(n.resultHandlers, handler...)
+}
+
+func (n *Node) isSelf(node registrySchema.Node) bool {
+	if n.Info().Node.AccId == node.AccId {
+		if n.Info().Node.URL == node.URL {
+			return true
+		}
+	}
+	return false
 }

--- a/node/node.go
+++ b/node/node.go
@@ -41,13 +41,13 @@ type Node struct {
 	resultHandlers      []schema.ResultHandler
 	resultHandlerLockMu sync.RWMutex
 
+	assignmentChan          chan schema.AssignmentResult
+	assignmentHandlers      []schema.AssignmentHandler
+	assignmentHandlerLockMu sync.RWMutex
+
 	outboxChan        <-chan vmmSchema.Outbox
 	outboxSendingLock map[string]bool
 	outboxLockMu      sync.RWMutex
-
-	// outbox assignment result channels
-	outboxAssignmentChans map[string]chan schema.AssignmentResult
-	outboxAssignmentMu    sync.RWMutex
 
 	db       schema.IDB
 	outboxDB schema.IDBOutbox
@@ -86,10 +86,11 @@ func New(
 		resultChan:     resultChan,
 		resultHandlers: []schema.ResultHandler{},
 
+		assignmentChan:     make(chan schema.AssignmentResult, 1000),
+		assignmentHandlers: []schema.AssignmentHandler{},
+
 		outboxChan:        outboxChan,
 		outboxSendingLock: map[string]bool{},
-
-		outboxAssignmentChans: map[string]chan schema.AssignmentResult{},
 
 		db:               rdb.New(redisURL),
 		outboxDB:         cache.NewOutbox(),
@@ -102,6 +103,7 @@ func (n *Node) Run() {
 	go n.runMsgChan()
 	go n.runProcChan()
 	go n.runResultChan()
+	go n.runAssignmentChan()
 	go n.runOutboxChan()
 	go n.runRecovery()
 
@@ -206,6 +208,25 @@ func (n *Node) AddResultHandler(handler ...schema.ResultHandler) {
 	defer n.resultHandlerLockMu.Unlock()
 
 	n.resultHandlers = append(n.resultHandlers, handler...)
+}
+
+func (n *Node) AddAssignmentHandler(handler ...schema.AssignmentHandler) {
+	n.assignmentHandlerLockMu.Lock()
+	defer n.assignmentHandlerLockMu.Unlock()
+
+	n.assignmentHandlers = append(n.assignmentHandlers, handler...)
+}
+
+func (n *Node) RemoveAssignmentHandler(handler schema.AssignmentHandler) {
+	n.assignmentHandlerLockMu.Lock()
+	defer n.assignmentHandlerLockMu.Unlock()
+
+	for i, h := range n.assignmentHandlers {
+		if &h == &handler {
+			n.assignmentHandlers = append(n.assignmentHandlers[:i], n.assignmentHandlers[i+1:]...)
+			break
+		}
+	}
 }
 
 func (n *Node) isSelf(node registrySchema.Node) bool {

--- a/node/outbox.go
+++ b/node/outbox.go
@@ -104,20 +104,20 @@ func (n *Node) trySend(pid, target string) {
 			return
 		}
 
+		var assignItem goarSchema.BundleItem
 		if n.isSelf(nodes[0]) {
-			log.Debug("outbox --- send to self")
-			_, err = n.tryGetLocalAssign(item.Id, nodes, *item)
+			assignItem, err = n.tryGetLocalAssign(item.Id, nodes, *item)
 			if err != nil {
 				log.Error("outbox try get local assignment failed", "pid", pid, "target", target, "itemId", item.Id, "err", err)
+				return
 			}
-			return
-		}
 
-		var assignItem goarSchema.BundleItem
-		assignItem, err = n.tryGetAssign(item.Id, nodes, itemBin)
-		if err != nil {
-			log.Error("outbox try get assignment failed", "pid", pid, "target", target, "itemId", item.Id, "err", err)
-			return
+		} else {
+			assignItem, err = n.tryGetAssign(item.Id, nodes, itemBin)
+			if err != nil {
+				log.Error("outbox try get assignment failed", "pid", pid, "target", target, "itemId", item.Id, "err", err)
+				return
+			}
 		}
 
 		if err = n.outboxDB.Commit(pid, target, assignItem); err != nil {
@@ -158,6 +158,10 @@ func (n *Node) tryGetLocalAssign(msgId string, nodes []registrySchema.Node, item
 		case assignmentResult := <-resultChan:
 			if assignmentResult.Error != nil {
 				err = assignmentResult.Error
+				if err == schema.ErrDuplicateItem {
+					log.Debug("outbox try get duplicate item, exit", "msgid", msgId)
+					return
+				}
 				continue
 			}
 			assignItem = assignmentResult.AssignItem
@@ -174,6 +178,7 @@ func (n *Node) tryGetLocalAssign(msgId string, nodes []registrySchema.Node, item
 				err = schema.ErrUnauthorizedNode
 				continue
 			}
+			log.Debug("outbox try get assign success", "msgid", msgId)
 			return
 		case <-time.After(2 * time.Second):
 			err = fmt.Errorf("timeout waiting for assignment result")

--- a/node/outbox.go
+++ b/node/outbox.go
@@ -100,7 +100,21 @@ func (n *Node) trySend(pid, target string) {
 			return
 		}
 
-		assignItem, err := n.tryGetAssign(item.Id, nodes, itemBin)
+		if len(nodes) == 0 {
+			return
+		}
+
+		if n.isSelf(nodes[0]) {
+			log.Debug("outbox --- send to self")
+			_, err = n.tryGetLocalAssign(item.Id, nodes, *item)
+			if err != nil {
+				log.Error("outbox try get local assignment failed", "pid", pid, "target", target, "itemId", item.Id, "err", err)
+			}
+			return
+		}
+
+		var assignItem goarSchema.BundleItem
+		assignItem, err = n.tryGetAssign(item.Id, nodes, itemBin)
 		if err != nil {
 			log.Error("outbox try get assignment failed", "pid", pid, "target", target, "itemId", item.Id, "err", err)
 			return
@@ -111,6 +125,63 @@ func (n *Node) trySend(pid, target string) {
 			return
 		}
 	}
+}
+
+func (n *Node) tryGetLocalAssign(msgId string, nodes []registrySchema.Node, item goarSchema.BundleItem) (assignItem goarSchema.BundleItem, err error) {
+	// make channel for assignment result
+	resultChan := make(chan schema.AssignmentResult, 1)
+	n.outboxAssignmentMu.Lock()
+	n.outboxAssignmentChans[msgId] = resultChan
+	n.outboxAssignmentMu.Unlock()
+
+	// clean channel
+	defer func() {
+		n.outboxAssignmentMu.Lock()
+		delete(n.outboxAssignmentChans, msgId)
+		n.outboxAssignmentMu.Unlock()
+		close(resultChan)
+	}()
+
+	for retry := 0; retry < 5; retry++ {
+		log.Debug("outbox try get assign retry", "retry", retry)
+		if retry > 0 {
+			time.Sleep(100 * time.Millisecond)
+		}
+
+		err = n.Handle(item)
+		if err != nil {
+			continue
+		}
+
+		// wait for assignment result
+		select {
+		case assignmentResult := <-resultChan:
+			if assignmentResult.Error != nil {
+				err = assignmentResult.Error
+				continue
+			}
+			assignItem = assignmentResult.AssignItem
+			err = goarUtils.VerifyBundleItem(assignItem)
+			if err != nil {
+				continue
+			}
+			accid := ""
+			_, accid, _, _, err = utils.Decode(assignItem)
+			if err != nil {
+				continue
+			}
+			if accid != nodes[0].AccId {
+				err = schema.ErrUnauthorizedNode
+				continue
+			}
+			return
+		case <-time.After(2 * time.Second):
+			err = fmt.Errorf("timeout waiting for assignment result")
+			continue
+		}
+	}
+
+	return
 }
 
 func (n *Node) tryGetAssign(msgId string, nodes []registrySchema.Node, itemBin []byte) (assignItem goarSchema.BundleItem, err error) {

--- a/node/outbox.go
+++ b/node/outbox.go
@@ -100,13 +100,9 @@ func (n *Node) trySend(pid, target string) {
 			return
 		}
 
-		if len(nodes) == 0 {
-			return
-		}
-
 		var assignItem goarSchema.BundleItem
 		if n.isSelf(nodes[0]) {
-			assignItem, err = n.tryGetLocalAssign(item.Id, *item)
+			assignItem, err = n.tryGetLocalAssign(*item)
 			if err != nil {
 				log.Error("outbox try get local assignment failed", "pid", pid, "target", target, "itemId", item.Id, "err", err)
 				return
@@ -127,14 +123,14 @@ func (n *Node) trySend(pid, target string) {
 	}
 }
 
-func (n *Node) tryGetLocalAssign(msgId string, item goarSchema.BundleItem) (assignItem goarSchema.BundleItem, err error) {
+func (n *Node) tryGetLocalAssign(item goarSchema.BundleItem) (assignItem goarSchema.BundleItem, err error) {
 	// Use callback function to wait for assignment result
 	resultChan := make(chan schema.AssignmentResult, 1)
 	closed := make(chan bool, 1)
 
 	// Create temporary assignment handler
 	handler := func(result schema.AssignmentResult) {
-		if result.Item.Id == msgId {
+		if result.Item.Id == item.Id {
 			select {
 			case <-closed:
 				// channel is closed, do nothing
@@ -173,12 +169,12 @@ func (n *Node) tryGetLocalAssign(msgId string, item goarSchema.BundleItem) (assi
 			if assignmentResult.Error != nil {
 				err = assignmentResult.Error
 				if err == schema.ErrDuplicateItem {
-					log.Debug("outbox try get duplicate item, exit", "msgid", msgId)
+					log.Debug("outbox try get duplicate item, exit", "msgid", item.Id)
 					return
 				}
 				continue
 			}
-			log.Debug("outbox try get assign success", "msgid", msgId)
+			log.Debug("outbox try get assign success", "msgid", item.Id)
 			return
 		case <-time.After(2 * time.Second):
 			err = fmt.Errorf("timeout waiting for assignment result")

--- a/node/outbox.go
+++ b/node/outbox.go
@@ -106,7 +106,7 @@ func (n *Node) trySend(pid, target string) {
 
 		var assignItem goarSchema.BundleItem
 		if n.isSelf(nodes[0]) {
-			assignItem, err = n.tryGetLocalAssign(item.Id, nodes, *item)
+			assignItem, err = n.tryGetLocalAssign(item.Id, *item)
 			if err != nil {
 				log.Error("outbox try get local assignment failed", "pid", pid, "target", target, "itemId", item.Id, "err", err)
 				return
@@ -127,27 +127,32 @@ func (n *Node) trySend(pid, target string) {
 	}
 }
 
-func (n *Node) tryGetLocalAssign(msgId string, nodes []registrySchema.Node, item goarSchema.BundleItem) (assignItem goarSchema.BundleItem, err error) {
+func (n *Node) tryGetLocalAssign(msgId string, item goarSchema.BundleItem) (assignItem goarSchema.BundleItem, err error) {
 	// Use callback function to wait for assignment result
 	resultChan := make(chan schema.AssignmentResult, 1)
-	
+	closed := make(chan bool, 1)
+
 	// Create temporary assignment handler
 	handler := func(result schema.AssignmentResult) {
-		if result.ItemId == msgId {
+		if result.Item.Id == msgId {
 			select {
-			case resultChan <- result:
+			case <-closed:
+				// channel is closed, do nothing
+				return
 			default:
-				// channel is full
 			}
+
+			resultChan <- result
 		}
 	}
-	
+
 	// Register handler
 	n.AddAssignmentHandler(handler)
 
 	// Ensure cleanup when function ends
 	defer func() {
 		n.RemoveAssignmentHandler(handler)
+		close(closed)
 		close(resultChan)
 	}()
 
@@ -156,7 +161,7 @@ func (n *Node) tryGetLocalAssign(msgId string, nodes []registrySchema.Node, item
 		if retry > 0 {
 			time.Sleep(100 * time.Millisecond)
 		}
-		
+
 		err = n.Handle(item)
 		if err != nil {
 			continue

--- a/node/outbox.go
+++ b/node/outbox.go
@@ -128,17 +128,26 @@ func (n *Node) trySend(pid, target string) {
 }
 
 func (n *Node) tryGetLocalAssign(msgId string, nodes []registrySchema.Node, item goarSchema.BundleItem) (assignItem goarSchema.BundleItem, err error) {
-	// make channel for assignment result
+	// Use callback function to wait for assignment result
 	resultChan := make(chan schema.AssignmentResult, 1)
-	n.outboxAssignmentMu.Lock()
-	n.outboxAssignmentChans[msgId] = resultChan
-	n.outboxAssignmentMu.Unlock()
+	
+	// Create temporary assignment handler
+	handler := func(result schema.AssignmentResult) {
+		if result.ItemId == msgId {
+			select {
+			case resultChan <- result:
+			default:
+				// channel is full
+			}
+		}
+	}
+	
+	// Register handler
+	n.AddAssignmentHandler(handler)
 
-	// clean channel
+	// Ensure cleanup when function ends
 	defer func() {
-		n.outboxAssignmentMu.Lock()
-		delete(n.outboxAssignmentChans, msgId)
-		n.outboxAssignmentMu.Unlock()
+		n.RemoveAssignmentHandler(handler)
 		close(resultChan)
 	}()
 
@@ -147,13 +156,13 @@ func (n *Node) tryGetLocalAssign(msgId string, nodes []registrySchema.Node, item
 		if retry > 0 {
 			time.Sleep(100 * time.Millisecond)
 		}
-
+		
 		err = n.Handle(item)
 		if err != nil {
 			continue
 		}
 
-		// wait for assignment result
+		// Wait for assignment result
 		select {
 		case assignmentResult := <-resultChan:
 			if assignmentResult.Error != nil {
@@ -162,20 +171,6 @@ func (n *Node) tryGetLocalAssign(msgId string, nodes []registrySchema.Node, item
 					log.Debug("outbox try get duplicate item, exit", "msgid", msgId)
 					return
 				}
-				continue
-			}
-			assignItem = assignmentResult.AssignItem
-			err = goarUtils.VerifyBundleItem(assignItem)
-			if err != nil {
-				continue
-			}
-			accid := ""
-			_, accid, _, _, err = utils.Decode(assignItem)
-			if err != nil {
-				continue
-			}
-			if accid != nodes[0].AccId {
-				err = schema.ErrUnauthorizedNode
 				continue
 			}
 			log.Debug("outbox try get assign success", "msgid", msgId)

--- a/node/schema/schema.go
+++ b/node/schema/schema.go
@@ -1,8 +1,10 @@
 package schema
 
 import (
+	hymxSchema "github.com/hymatrix/hymx/schema"
 	registrySchema "github.com/hymatrix/hymx/vmm/core/registry/schema"
 	vmmSchema "github.com/hymatrix/hymx/vmm/schema"
+	goarSchema "github.com/permadao/goar/schema"
 )
 
 type Info struct {
@@ -15,3 +17,13 @@ type Info struct {
 }
 
 type ResultHandler func(vmmSchema.Result)
+
+type AssignmentResult struct {
+	Assign     hymxSchema.Assignment
+	AssignItem goarSchema.BundleItem
+	Error      error
+	Pid        string
+	ItemId     string
+}
+
+type AssignmentHandler func(AssignmentResult)

--- a/node/schema/schema.go
+++ b/node/schema/schema.go
@@ -19,11 +19,11 @@ type Info struct {
 type ResultHandler func(vmmSchema.Result)
 
 type AssignmentResult struct {
+	Pid        string
+	Item       goarSchema.BundleItem
 	Assign     hymxSchema.Assignment
 	AssignItem goarSchema.BundleItem
 	Error      error
-	Pid        string
-	ItemId     string
 }
 
 type AssignmentHandler func(AssignmentResult)


### PR DESCRIPTION
Description

feat: Optimization - Local node messages are now processed directly via channels instead of HTTP protocol  

• In outbox trySend, check if the target is the local node. If so, directly invoke node.Handle.  

• Subscription handling for outbox assignment results: A map (msgid -> chan) is added to the node. If outbox subscribes to assignment results, they are sent directly to outbox via the channel. (map[string]chan schema.AssignmentResult)  

• For local messages, outbox waits for the assignment channel result after calling node.Handle.  

• Retry mechanism: Timeout or failure triggers up to 5 retry attempts.