### PR TITLE
Featrue/redirect

### DIFF
--- a/node/handle.go
+++ b/node/handle.go
@@ -87,8 +87,8 @@ func (n *Node) Handle(item goarSchema.BundleItem) (err error) {
 	case hymxSchema.Message:
 		// check if need redirect
 		if isRedirect {
-			// todo: return nodes, schema.ErrRedirect
-			err = schema.ErrRedirect
+			// return nodes with redirect error for 308 redirect
+			err = schema.NewRedirectError(nodes)
 			log.Warn("handle message failed", "pid", pid, "err", err)
 			return
 		}

--- a/node/handle.go
+++ b/node/handle.go
@@ -17,7 +17,7 @@ func (n *Node) Handle(item goarSchema.BundleItem) (err error) {
 		return
 	}
 
-	pid, accid, fromProcess, instance, err := utils.Decode(item)
+	pid, signer, fromProcess, instance, err := utils.Decode(item)
 	if err != nil {
 		return
 	}
@@ -32,13 +32,13 @@ func (n *Node) Handle(item goarSchema.BundleItem) (err error) {
 			// Verify register process(spawned) message
 			// For registry messages, the fromProcess should be the same as the process being registered
 			// and the accid should be registered in the node list
-			if err = n.verifyRegistryMessage(item, fromProcess); err != nil {
-				log.Error("verify registry process message failed", "pid", pid, "accid", accid, "fromProcess", fromProcess)
+			if err = n.verifyRegistryMessage(item, signer, fromProcess); err != nil {
+				log.Error("verify registry process message failed", "pid", pid, "signer", signer, "fromProcess", fromProcess)
 				return
 			}
 		} else {
-			if err = n.authNode(accid, fromProcess); err != nil {
-				log.Error("auth node failed", "pid", pid, "accid", accid, "fromProcess", fromProcess)
+			if err = n.authNode(signer, fromProcess); err != nil {
+				log.Error("auth node failed", "pid", pid, "signer", signer, "fromProcess", fromProcess)
 				return
 			}
 		}
@@ -81,7 +81,7 @@ func (n *Node) Handle(item goarSchema.BundleItem) (err error) {
 
 		n.assignProcChan <- schema.AssignProcess{
 			Pid:     pid,
-			AccId:   accid,
+			AccId:   signer,
 			Process: v,
 			Item:    item,
 		}
@@ -103,7 +103,7 @@ func (n *Node) Handle(item goarSchema.BundleItem) (err error) {
 
 		n.assignMesChan <- schema.AssignMessage{
 			Pid:     pid,
-			AccId:   accid,
+			AccId:   signer,
 			Message: v,
 			Item:    item,
 		}
@@ -168,7 +168,7 @@ func (n *Node) authNode(accid, fromProcess string) (err error) {
 }
 
 // verifyRegistryMessage verifies registry process registration messages with 4 steps
-func (n *Node) verifyRegistryMessage(item goarSchema.BundleItem, fromProcess string) (err error) {
+func (n *Node) verifyRegistryMessage(item goarSchema.BundleItem, signer, fromProcess string) (err error) {
 	// 1. get 'Pid' and 'Acc-Id' from Tags
 	pid := utils.GetTagsValue("Pid", item.Tags)
 	accid := utils.GetTagsValue("Acc-Id", item.Tags)
@@ -188,19 +188,19 @@ func (n *Node) verifyRegistryMessage(item goarSchema.BundleItem, fromProcess str
 	// * pid is the id of the spawn message that created the process
 	// * so we can use pid to query the original message
 	var spawnMsg *goarSchema.BundleItem
-	if accid == n.Info().Node.AccId { // get message from local
+	if signer == n.Info().Node.AccId { // get message from local
 		spawnMsg, err = n.GetMessage(pid)
 		if err != nil {
 			return errors.New("get origin spawn message failed, msgid: " + pid)
 		}
 	} else { // get message from other node
 		var node *registrySchema.Node
-		node, err = n.GetNode(accid)
+		node, err = n.GetNode(signer)
 		if err != nil {
 			return
 		}
 		if node == nil {
-			return errors.New("node not found, accid: " + accid)
+			return errors.New("node not found, accid: " + signer)
 		}
 		cli := sdk.NewClient(node.URL)
 		msg, msgErr := cli.GetMessage(pid)

--- a/node/handle.go
+++ b/node/handle.go
@@ -32,9 +32,14 @@ func (n *Node) Handle(item goarSchema.BundleItem) (err error) {
 			// Verify register process(spawned) message
 			// For registry messages, the fromProcess should be the same as the process being registered
 			// and the accid should be registered in the node list
-			if err = n.verifyRegistryMessage(item, signer, fromProcess); err != nil {
-				log.Error("verify registry process message failed", "pid", pid, "signer", signer, "fromProcess", fromProcess)
-				return
+
+			// Verify this is a RegisterProcess action
+			action := utils.GetTagsValue("Action", item.Tags)
+			if action == "RegisterProcess" {
+				if err = n.verifyRegistryMessage(item, signer, fromProcess); err != nil {
+					log.Error("verify registry process message failed", "pid", pid, "signer", signer, "fromProcess", fromProcess, "err", err)
+					return
+				}
 			}
 		} else {
 			if err = n.authNode(signer, fromProcess); err != nil {
@@ -172,13 +177,6 @@ func (n *Node) verifyRegistryMessage(item goarSchema.BundleItem, signer, fromPro
 	// 1. get 'Pid' and 'Acc-Id' from Tags
 	pid := utils.GetTagsValue("Pid", item.Tags)
 	accid := utils.GetTagsValue("Acc-Id", item.Tags)
-	action := utils.GetTagsValue("Action", item.Tags)
-
-	// Verify this is a RegisterProcess action
-	if action != "RegisterProcess" {
-		return schema.ErrInvalidType
-	}
-
 	if pid == "" || accid == "" {
 		log.Error("missing required tags in registry message", "Pid", pid, "Acc-Id", accid)
 		return schema.ErrUnauthorizedNode

--- a/node/handle.go
+++ b/node/handle.go
@@ -110,32 +110,22 @@ func (n *Node) verifyFromProcess(item goarSchema.BundleItem, pid, signer, fromPr
 
 	// Handle registry process verification
 	if pid == n.vmm.RegistryId() {
-		return n.verifyRegistryProcess(item, pid, signer, fromProcess)
+		// return n.verifyRegistryProcess(item, pid, signer, fromProcess)
+		// Verify this is a RegisterProcess action
+		action := utils.GetTagsValue("Action", item.Tags)
+		if action != "RegisterProcess" {
+			return nil
+		}
+
+		if err := n.verifyRegistry(item, signer, fromProcess); err != nil {
+			log.Error("verify registry process message failed", "pid", pid, "signer", signer, "fromProcess", fromProcess, "err", err)
+			return err
+		}
 	}
 
 	// Handle regular node authentication
 	if err := n.authNode(signer, fromProcess); err != nil {
 		log.Error("auth node failed", "pid", pid, "signer", signer, "fromProcess", fromProcess)
-		return err
-	}
-
-	return nil
-}
-
-// verifyRegistryProcess handles registry process verification
-func (n *Node) verifyRegistryProcess(item goarSchema.BundleItem, pid, signer, fromProcess string) error {
-	// Verify register process(spawned) message
-	// For registry messages, the fromProcess should be the same as the process being registered
-	// and the accid should be registered in the node list
-
-	// Verify this is a RegisterProcess action
-	action := utils.GetTagsValue("Action", item.Tags)
-	if action != "RegisterProcess" {
-		return nil
-	}
-
-	if err := n.verifyRegistryMessage(item, signer, fromProcess); err != nil {
-		log.Error("verify registry process message failed", "pid", pid, "signer", signer, "fromProcess", fromProcess, "err", err)
 		return err
 	}
 
@@ -195,8 +185,8 @@ func (n *Node) authNode(accid, fromProcess string) (err error) {
 	return
 }
 
-// verifyRegistryMessage verifies registry process registration messages with 4 steps
-func (n *Node) verifyRegistryMessage(item goarSchema.BundleItem, signer, fromProcess string) (err error) {
+// verifyRegistry verifies registry process registration messages with 4 steps
+func (n *Node) verifyRegistry(item goarSchema.BundleItem, signer, fromProcess string) (err error) {
 	// 1. get 'Pid' and 'Acc-Id' from Tags
 	pid := utils.GetTagsValue("Pid", item.Tags)
 	accid := utils.GetTagsValue("Acc-Id", item.Tags)

--- a/node/handle.go
+++ b/node/handle.go
@@ -95,7 +95,7 @@ func (n *Node) Handle(item goarSchema.BundleItem) (err error) {
 		if isRedirect {
 			// return nodes with redirect error for 308 redirect
 			err = schema.NewRedirectError(nodes)
-			log.Warn("handle message failed", "pid", pid, "err", err)
+			log.Warn("message redirect", "pid", pid, "err", err)
 			return
 		}
 

--- a/node/handle.go
+++ b/node/handle.go
@@ -1,6 +1,8 @@
 package node
 
 import (
+	"errors"
+
 	"github.com/hymatrix/hymx/node/schema"
 	hymxSchema "github.com/hymatrix/hymx/schema"
 	"github.com/hymatrix/hymx/utils"
@@ -26,7 +28,13 @@ func (n *Node) Handle(item goarSchema.BundleItem) (err error) {
 	// If this io a registration request sent to the registry, this step is skipped.
 	if fromProcess != "" {
 		if pid == n.vmm.RegistryId() {
-			// todo: need verify register process(spawned) message
+			// Verify register process(spawned) message
+			// For registry messages, the fromProcess should be the same as the process being registered
+			// and the accid should be registered in the node list
+			if err = n.verifyRegistryMessage(item, fromProcess); err != nil {
+				log.Error("verify registry process message failed", "pid", pid, "accid", accid, "fromProcess", fromProcess)
+				return
+			}
 		} else {
 			if err = n.authNode(accid, fromProcess); err != nil {
 				log.Error("auth node failed", "pid", pid, "accid", accid, "fromProcess", fromProcess)
@@ -152,6 +160,49 @@ func (n *Node) authNode(accid, fromProcess string) (err error) {
 	}
 	if !validNode {
 		log.Error("auth node failed", "accid", accid, "fromProcess", fromProcess)
+		return schema.ErrUnauthorizedNode
+	}
+
+	return
+}
+
+// verifyRegistryMessage verifies registry process registration messages with 4 steps
+func (n *Node) verifyRegistryMessage(item goarSchema.BundleItem, fromProcess string) (err error) {
+	// 1. get 'Pid' and 'Acc-Id' from Tags
+	pid := utils.GetTagsValue("Pid", item.Tags)
+	accid := utils.GetTagsValue("Acc-Id", item.Tags)
+	action := utils.GetTagsValue("Action", item.Tags)
+
+	// Verify this is a RegisterProcess action
+	if action != "RegisterProcess" {
+		return schema.ErrInvalidType
+	}
+
+	if pid == "" || accid == "" {
+		log.Error("missing required tags in registry message", "Pid", pid, "Acc-Id", accid)
+		return schema.ErrUnauthorizedNode
+	}
+
+	// 2. get original message by 'Pid'
+	// * pid is the id of the spawn message that created the process
+	// * so we can use pid to query the original message
+	spawnMsg, err := n.GetMessage(pid)
+	if err != nil {
+		return errors.New("get origin spawn message failed, msgid: " + pid)
+	}
+	if spawnMsg == nil {
+		return errors.New("spawn message not found, msgid: " + pid)
+	}
+
+	// 3. verify original message
+	if err = goarUtils.VerifyBundleItem(*spawnMsg); err != nil {
+		return
+	}
+
+	// 4. Validate that the spawn message's scheduler matches the node via RegisterProcess.​
+	scheduler := utils.GetTagsValue("Scheduler", spawnMsg.Tags)
+	if accid != scheduler {
+		log.Error("verify registry message failed, node accid not match", "pid", pid, "accid", accid, "fromProcess", fromProcess, "scheduler", scheduler)
 		return schema.ErrUnauthorizedNode
 	}
 

--- a/node/handle.go
+++ b/node/handle.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hymatrix/hymx/node/schema"
 	hymxSchema "github.com/hymatrix/hymx/schema"
+	"github.com/hymatrix/hymx/sdk"
 	"github.com/hymatrix/hymx/utils"
 	registrySchema "github.com/hymatrix/hymx/vmm/core/registry/schema"
 	goarSchema "github.com/permadao/goar/schema"
@@ -186,10 +187,29 @@ func (n *Node) verifyRegistryMessage(item goarSchema.BundleItem, fromProcess str
 	// 2. get original message by 'Pid'
 	// * pid is the id of the spawn message that created the process
 	// * so we can use pid to query the original message
-	spawnMsg, err := n.GetMessage(pid)
-	if err != nil {
-		return errors.New("get origin spawn message failed, msgid: " + pid)
+	var spawnMsg *goarSchema.BundleItem
+	if accid == n.Info().Node.AccId { // get message from local
+		spawnMsg, err = n.GetMessage(pid)
+		if err != nil {
+			return errors.New("get origin spawn message failed, msgid: " + pid)
+		}
+	} else { // get message from other node
+		var node *registrySchema.Node
+		node, err = n.GetNode(accid)
+		if err != nil {
+			return
+		}
+		if node == nil {
+			return errors.New("node not found, accid: " + accid)
+		}
+		cli := sdk.NewClient(node.URL)
+		msg, msgErr := cli.GetMessage(pid)
+		if msgErr != nil {
+			return errors.New("get origin spawn message failed, msgid: " + pid)
+		}
+		spawnMsg = &msg
 	}
+
 	if spawnMsg == nil {
 		return errors.New("spawn message not found, msgid: " + pid)
 	}

--- a/node/handle.go
+++ b/node/handle.go
@@ -27,26 +27,8 @@ func (n *Node) Handle(item goarSchema.BundleItem) (err error) {
 	// If the accid is registered in the node list, it is allowed to send a From-Process message.
 	// The From-Process value must also be registered under the corresponding node.
 	// If this io a registration request sent to the registry, this step is skipped.
-	if fromProcess != "" {
-		if pid == n.vmm.RegistryId() {
-			// Verify register process(spawned) message
-			// For registry messages, the fromProcess should be the same as the process being registered
-			// and the accid should be registered in the node list
-
-			// Verify this is a RegisterProcess action
-			action := utils.GetTagsValue("Action", item.Tags)
-			if action == "RegisterProcess" {
-				if err = n.verifyRegistryMessage(item, signer, fromProcess); err != nil {
-					log.Error("verify registry process message failed", "pid", pid, "signer", signer, "fromProcess", fromProcess, "err", err)
-					return
-				}
-			}
-		} else {
-			if err = n.authNode(signer, fromProcess); err != nil {
-				log.Error("auth node failed", "pid", pid, "signer", signer, "fromProcess", fromProcess)
-				return
-			}
-		}
+	if err = n.verifyFromProcess(item, pid, signer, fromProcess); err != nil {
+		return
 	}
 
 	// check if process in recovering
@@ -117,6 +99,47 @@ func (n *Node) Handle(item goarSchema.BundleItem) (err error) {
 	}
 
 	return
+}
+
+// verifyFromProcess verifies the fromProcess authentication
+// It handles both registry process verification and regular node authentication
+func (n *Node) verifyFromProcess(item goarSchema.BundleItem, pid, signer, fromProcess string) error {
+	if fromProcess == "" {
+		return nil
+	}
+
+	// Handle registry process verification
+	if pid == n.vmm.RegistryId() {
+		return n.verifyRegistryProcess(item, pid, signer, fromProcess)
+	}
+
+	// Handle regular node authentication
+	if err := n.authNode(signer, fromProcess); err != nil {
+		log.Error("auth node failed", "pid", pid, "signer", signer, "fromProcess", fromProcess)
+		return err
+	}
+
+	return nil
+}
+
+// verifyRegistryProcess handles registry process verification
+func (n *Node) verifyRegistryProcess(item goarSchema.BundleItem, pid, signer, fromProcess string) error {
+	// Verify register process(spawned) message
+	// For registry messages, the fromProcess should be the same as the process being registered
+	// and the accid should be registered in the node list
+
+	// Verify this is a RegisterProcess action
+	action := utils.GetTagsValue("Action", item.Tags)
+	if action != "RegisterProcess" {
+		return nil
+	}
+
+	if err := n.verifyRegistryMessage(item, signer, fromProcess); err != nil {
+		log.Error("verify registry process message failed", "pid", pid, "signer", signer, "fromProcess", fromProcess, "err", err)
+		return err
+	}
+
+	return nil
 }
 
 func (n *Node) HandleDryRun(item goarSchema.BundleItem, assign hymxSchema.Assignment, maxNonce int64) (err error) {

--- a/node/handle.go
+++ b/node/handle.go
@@ -121,6 +121,7 @@ func (n *Node) verifyFromProcess(item goarSchema.BundleItem, pid, signer, fromPr
 			log.Error("verify registry process message failed", "pid", pid, "signer", signer, "fromProcess", fromProcess, "err", err)
 			return err
 		}
+		return nil
 	}
 
 	// Handle regular node authentication

--- a/node/redirect_test.go
+++ b/node/redirect_test.go
@@ -1,0 +1,147 @@
+package node
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/hymatrix/hymx/node/schema"
+	registrySchema "github.com/hymatrix/hymx/vmm/core/registry/schema"
+)
+
+// TestRedirectResponse tests basic 308 redirect with multiple nodes
+func TestRedirectResponse(t *testing.T) {
+	// Create test nodes
+	nodes := []registrySchema.Node{
+		{
+			AccId: "test-node-1",
+			Name:  "Test Node 1",
+			Role:  "main",
+			Desc:  "Test redirect node",
+			URL:   "http://node1.example.com:8080",
+		},
+		{
+			AccId: "test-node-2",
+			Name:  "Test Node 2",
+			Role:  "follower",
+			Desc:  "Test redirect node 2",
+			URL:   "http://node2.example.com:8080",
+		},
+	}
+
+	// Create redirect error
+	redirectErr := schema.NewRedirectError(nodes)
+
+	// Setup test server
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+
+	router.POST("/submit", func(c *gin.Context) {
+		// Simulate redirect error handling
+		if len(redirectErr.Nodes) > 0 {
+			// Set Location header to the first available node URL for browser auto-redirect
+			c.Header("Location", redirectErr.Nodes[0].URL)
+		}
+		// Also return nodes information in response body for client SDK usage
+		c.JSON(http.StatusPermanentRedirect, redirectErr.Nodes)
+	})
+
+	// Test the redirect response
+	req := httptest.NewRequest("POST", "/submit", strings.NewReader(`{"test": "data"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	// Verify results
+	if w.Code != http.StatusPermanentRedirect {
+		t.Errorf("Expected status code %d, got %d", http.StatusPermanentRedirect, w.Code)
+	}
+	if location := w.Header().Get("Location"); location != "http://node1.example.com:8080" {
+		t.Errorf("Expected Location header 'http://node1.example.com:8080', got '%s'", location)
+	}
+	if contentType := w.Header().Get("Content-Type"); contentType != "application/json; charset=utf-8" {
+		t.Errorf("Expected Content-Type 'application/json; charset=utf-8', got '%s'", contentType)
+	}
+}
+
+// TestEmptyNodesRedirect tests redirect with empty nodes list
+func TestEmptyNodesRedirect(t *testing.T) {
+	// Create redirect error with empty nodes
+	redirectErr := schema.NewRedirectError([]registrySchema.Node{})
+
+	// Setup test server
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+
+	router.POST("/submit", func(c *gin.Context) {
+		// Simulate redirect error handling with empty nodes
+		if len(redirectErr.Nodes) > 0 {
+			c.Header("Location", redirectErr.Nodes[0].URL)
+		}
+		c.JSON(http.StatusPermanentRedirect, redirectErr.Nodes)
+	})
+
+	// Test the redirect response
+	req := httptest.NewRequest("POST", "/submit", strings.NewReader(`{"test": "data"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	// Verify results
+	if w.Code != http.StatusPermanentRedirect {
+		t.Errorf("Expected status code %d, got %d", http.StatusPermanentRedirect, w.Code)
+	}
+	if location := w.Header().Get("Location"); location != "" {
+		t.Errorf("Expected empty Location header, got '%s'", location)
+	}
+	if body := w.Body.String(); body != "[]" {
+		t.Errorf("Expected empty array '[]', got '%s'", body)
+	}
+}
+
+// TestSingleNodeRedirect tests redirect with single node
+func TestSingleNodeRedirect(t *testing.T) {
+	// Create single test node
+	nodes := []registrySchema.Node{
+		{
+			AccId: "single-node",
+			Name:  "Single Node",
+			Role:  "main",
+			Desc:  "Single test node",
+			URL:   "http://single.example.com:8080",
+		},
+	}
+
+	// Create redirect error
+	redirectErr := schema.NewRedirectError(nodes)
+
+	// Setup test server
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+
+	router.POST("/submit", func(c *gin.Context) {
+		if len(redirectErr.Nodes) > 0 {
+			c.Header("Location", redirectErr.Nodes[0].URL)
+		}
+		c.JSON(http.StatusPermanentRedirect, redirectErr.Nodes)
+	})
+
+	// Test the redirect response
+	req := httptest.NewRequest("POST", "/submit", strings.NewReader(`{"test": "data"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	// Verify results
+	if w.Code != http.StatusPermanentRedirect {
+		t.Errorf("Expected status code %d, got %d", http.StatusPermanentRedirect, w.Code)
+	}
+	if location := w.Header().Get("Location"); location != "http://single.example.com:8080" {
+		t.Errorf("Expected Location header 'http://single.example.com:8080', got '%s'", location)
+	}
+}

--- a/node/schema/errors.go
+++ b/node/schema/errors.go
@@ -1,6 +1,9 @@
 package schema
 
-import "errors"
+import (
+	"errors"
+	registrySchema "github.com/hymatrix/hymx/vmm/core/registry/schema"
+)
 
 var (
 	ErrInvalidType               = errors.New("err_invalid_type")
@@ -15,3 +18,17 @@ var (
 	ErrUnrecognizedSignatureType = errors.New("err_unrecognized_signature_type")
 	ErrUnauthorizedNode          = errors.New("err_unauthorized_node")
 )
+
+// RedirectError contains nodes information for 308 redirect
+type RedirectError struct {
+	Nodes []registrySchema.Node `json:"nodes"`
+}
+
+func (e *RedirectError) Error() string {
+	return "err_redirect"
+}
+
+// NewRedirectError creates a new redirect error with nodes information
+func NewRedirectError(nodes []registrySchema.Node) *RedirectError {
+	return &RedirectError{Nodes: nodes}
+}

--- a/sdk/async.go
+++ b/sdk/async.go
@@ -36,12 +36,20 @@ func (s *SDK) ResultAndWait(msgid string) (result vmmSchema.Result, err error) {
 }
 
 func (s *SDK) SendAndWait(processId, data string, tags []goarSchema.Tag) (res *serverSchema.Response, err error) {
-	res, err = s.Send(processId, data, tags)
+	var redirectUrl string
+	res, redirectUrl, err = s.Send(processId, data, tags)
 	if err != nil {
 		return
 	}
 
-	result, err := s.ResultAndWait(res.Id)
+	// Handle redirect
+	realSdk := s
+	if redirectUrl != "" {
+		log.Debug("redirect to url", "url", redirectUrl)
+		realSdk = NewFromBundler(redirectUrl, s.Bundler)
+	}
+
+	result, err := realSdk.ResultAndWait(res.Id)
 	if err != nil {
 		return
 	}

--- a/sdk/async.go
+++ b/sdk/async.go
@@ -47,6 +47,7 @@ func (s *SDK) SendAndWait(processId, data string, tags []goarSchema.Tag) (res *s
 	if redirectUrl != "" {
 		log.Debug("redirect to url", "url", redirectUrl)
 		realSdk = NewFromBundler(redirectUrl, s.Bundler)
+		defer realSdk.Close()
 	}
 
 	result, err := realSdk.ResultAndWait(res.Id)

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -59,7 +59,6 @@ func (c *Client) buildURL(path string) (string, error) {
 
 // handleRedirect handles 308 redirect responses by trying alternative nodes
 func (c *Client) handleRedirect(resp *http.Response, originalReq *http.Request, originalBody []byte) (*http.Response, string, error) {
-	log.Debug("===> status code", "code", resp.StatusCode)
 	if resp.StatusCode != 308 {
 		return resp, "", nil
 	}

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -12,6 +12,7 @@ import (
 
 	nodeSchema "github.com/hymatrix/hymx/node/schema"
 	serverSchema "github.com/hymatrix/hymx/server/schema"
+	registrySchema "github.com/hymatrix/hymx/vmm/core/registry/schema"
 	vmmSchema "github.com/hymatrix/hymx/vmm/schema"
 	goarSchema "github.com/permadao/goar/schema"
 )
@@ -44,30 +45,47 @@ func (c *Client) Close() {
 	c.httpClient.CloseIdleConnections()
 }
 
+func (c *Client) buildURL(path string) (string, error) {
+	baseURL, err := url.Parse(c.baseURL)
+	if err != nil {
+		return "", err
+	}
+	relativePath, err := url.Parse(path)
+	if err != nil {
+		return "", err
+	}
+	return baseURL.ResolveReference(relativePath).String(), nil
+}
+
 // handleRedirect handles 308 redirect responses by trying alternative nodes
-func (c *Client) handleRedirect(resp *http.Response, originalReq *http.Request, originalBody []byte) (*http.Response, error) {
+func (c *Client) handleRedirect(resp *http.Response, originalReq *http.Request, originalBody []byte) (*http.Response, string, error) {
+	log.Debug("===> status code", "code", resp.StatusCode)
 	if resp.StatusCode != 308 {
-		return resp, nil
+		return resp, "", nil
 	}
 
 	// Read redirect response body
 	body, err := io.ReadAll(resp.Body)
 	resp.Body.Close()
 	if err != nil {
-		return nil, fmt.Errorf("failed to read redirect response: %w", err)
+		return nil, "", fmt.Errorf("failed to read redirect response: %w", err)
 	}
 
 	// Parse nodes from response
-	var redirectResp nodeSchema.RedirectError
-	if err := json.Unmarshal(body, &redirectResp); err != nil {
-		return nil, fmt.Errorf("failed to parse redirect response: %w", err)
+	// Try to parse as RedirectError first (standard format)
+	var nodes []registrySchema.Node
+	if err := json.Unmarshal(body, &nodes); err != nil {
+		log.Error("unmarshal redirect response failed", "body", string(body), "err", err)
+		return nil, "", fmt.Errorf("failed to parse redirect response: %w", err)
 	}
 
 	// Try each node in the redirect response
-	for _, node := range redirectResp.Nodes {
+	for _, node := range nodes {
+		fmt.Println("get node url", node.URL)
 		// Create new request with the same method, path, and body as original
 		newURL, err := url.Parse(node.URL)
 		if err != nil {
+			log.Error("parse node url failed", "url", node.URL, "err", err)
 			continue
 		}
 		if newURL.Path == "" || newURL.Path == "/" {
@@ -78,6 +96,7 @@ func (c *Client) handleRedirect(resp *http.Response, originalReq *http.Request, 
 		// Create new request with original body
 		newReq, err := http.NewRequest(originalReq.Method, newURL.String(), bytes.NewReader(originalBody))
 		if err != nil {
+			log.Error("create new request failed", "url", newURL.String(), "err", err)
 			continue // Skip invalid URLs
 		}
 
@@ -94,14 +113,17 @@ func (c *Client) handleRedirect(resp *http.Response, originalReq *http.Request, 
 		newReq.Close = originalReq.Close
 
 		// Execute request to alternative node
+		log.Debug("send redirect msg", "new url", newURL, "ori url", originalReq.URL.String())
 		newResp, err := c.httpClient.Do(newReq)
 		if err != nil {
+			log.Error("send redirect msg failed", "new url", newURL, "ori url", originalReq.URL.String(), "err", err)
 			continue // Try next node
 		}
 
-		// If successful (2xx status), return this response
+		// If successful (2xx status), return this response with the redirected URL
 		if newResp.StatusCode >= 200 && newResp.StatusCode < 300 {
-			return newResp, nil
+			log.Debug("send redirect msg success", "new url", newURL, "ori url", originalReq.URL.String(), "statusCode", newResp.StatusCode)
+			return newResp, newURL.String(), nil
 		}
 
 		// If still 308, try next node
@@ -114,44 +136,47 @@ func (c *Client) handleRedirect(resp *http.Response, originalReq *http.Request, 
 		Status:     "308 Permanent Redirect",
 		Body:       io.NopCloser(bytes.NewReader(body)),
 		Header:     resp.Header,
-	}, nil
+	}, "", nil
 }
 
-func (c *Client) Send(itemBin []byte) (res *serverSchema.Response, err error) {
-	url := fmt.Sprintf("%s/", c.baseURL)
-	req, err := http.NewRequest("POST", url, bytes.NewBuffer(itemBin))
+func (c *Client) Send(itemBin []byte) (res *serverSchema.Response, redirectedURL string, err error) {
+	endpointURL, err := c.buildURL("/")
 	if err != nil {
-		return nil, err
+		return nil, "", err
+	}
+
+	req, err := http.NewRequest("POST", endpointURL, bytes.NewBuffer(itemBin))
+	if err != nil {
+		return nil, "", err
 	}
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	// Handle 308 redirect
-	resp, err = c.handleRedirect(resp, req, itemBin)
+	resp, redirectedURL, err = c.handleRedirect(resp, req, itemBin)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		// If it's a 308 redirect that couldn't be resolved, return nil response
-		if resp.StatusCode == 308 {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("invalid server response: %d", resp.StatusCode)
+		return nil, "", fmt.Errorf("invalid server response: %d", resp.StatusCode)
 	}
 
 	res = &serverSchema.Response{}
 	err = json.NewDecoder(resp.Body).Decode(res)
-	return res, err
+	return res, redirectedURL, err
 }
 
 func (c *Client) Info() (info nodeSchema.Info, err error) {
-	url := fmt.Sprintf("%s/info", c.baseURL)
+	url, err := c.buildURL("/info")
+	if err != nil {
+		return
+	}
 	resp, err := c.httpClient.Get(url)
 	if err != nil {
 		return
@@ -169,7 +194,10 @@ func (c *Client) Info() (info nodeSchema.Info, err error) {
 
 func (c *Client) Callback(targetURL string) (res string, err error) {
 	encoded := url.QueryEscape(targetURL)
-	fullURL := fmt.Sprintf("%s/callback?url=%s", c.baseURL, encoded)
+	fullURL, err := c.buildURL("/callback?url=" + encoded)
+	if err != nil {
+		return
+	}
 
 	resp, err := c.httpClient.Get(fullURL)
 	if err != nil {
@@ -191,8 +219,16 @@ func (c *Client) Callback(targetURL string) (res string, err error) {
 }
 
 func (c *Client) GetResult(msgid string) (result vmmSchema.Result, err error) {
-	url := fmt.Sprintf("%s/result/%s", c.baseURL, msgid)
-	resp, err := c.httpClient.Get(url)
+	url, err := c.buildURL("/result/" + msgid)
+	if err != nil {
+		return
+	}
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return
+	}
+
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return
 	}
@@ -208,8 +244,17 @@ func (c *Client) GetResult(msgid string) (result vmmSchema.Result, err error) {
 }
 
 func (c *Client) GetResults(pid string, limit int64) (results []vmmSchema.Result, err error) {
-	url := fmt.Sprintf("%s/results/%s?sort=DESC&limit=%d", c.baseURL, pid, limit)
-	resp, err := c.httpClient.Get(url)
+	path := fmt.Sprintf("/results/%s?sort=DESC&limit=%d", pid, limit)
+	url, err := c.buildURL(path)
+	if err != nil {
+		return
+	}
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return
+	}
+
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return
 	}
@@ -225,8 +270,16 @@ func (c *Client) GetResults(pid string, limit int64) (results []vmmSchema.Result
 }
 
 func (c *Client) GetMessage(msgid string) (item goarSchema.BundleItem, err error) {
-	url := fmt.Sprintf("%s/message/%s", c.baseURL, msgid)
-	resp, err := c.httpClient.Get(url)
+	url, err := c.buildURL("/message/" + msgid)
+	if err != nil {
+		return
+	}
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return
+	}
+
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return
 	}
@@ -242,7 +295,11 @@ func (c *Client) GetMessage(msgid string) (item goarSchema.BundleItem, err error
 }
 
 func (c *Client) GetMessageByNonce(pid string, nonce int64) (item goarSchema.BundleItem, err error) {
-	url := fmt.Sprintf("%s/messageByNonce/%s/%d", c.baseURL, pid, nonce)
+	path := fmt.Sprintf("/messageByNonce/%s/%d", pid, nonce)
+	url, err := c.buildURL(path)
+	if err != nil {
+		return
+	}
 	resp, err := c.httpClient.Get(url)
 	if err != nil {
 		return
@@ -259,7 +316,11 @@ func (c *Client) GetMessageByNonce(pid string, nonce int64) (item goarSchema.Bun
 }
 
 func (c *Client) GetAssignByNonce(pid string, nonce int64) (item goarSchema.BundleItem, err error) {
-	url := fmt.Sprintf("%s/assignmentByNonce/%s/%d", c.baseURL, pid, nonce)
+	path := fmt.Sprintf("/assignmentByNonce/%s/%d", pid, nonce)
+	url, err := c.buildURL(path)
+	if err != nil {
+		return
+	}
 	resp, err := c.httpClient.Get(url)
 	if err != nil {
 		return
@@ -276,7 +337,10 @@ func (c *Client) GetAssignByNonce(pid string, nonce int64) (item goarSchema.Bund
 }
 
 func (c *Client) GetAssignByMessage(msgid string) (item goarSchema.BundleItem, err error) {
-	url := fmt.Sprintf("%s/assignmentByMessage/%s", c.baseURL, msgid)
+	url, err := c.buildURL("/assignmentByMessage/" + msgid)
+	if err != nil {
+		return
+	}
 	resp, err := c.httpClient.Get(url)
 	if err != nil {
 		return
@@ -293,7 +357,10 @@ func (c *Client) GetAssignByMessage(msgid string) (item goarSchema.BundleItem, e
 }
 
 func (c *Client) BalanceOf(accid string) (amt *big.Int, err error) {
-	url := fmt.Sprintf("%s/balanceof/%s", c.baseURL, accid)
+	url, err := c.buildURL("/balanceof/" + accid)
+	if err != nil {
+		return
+	}
 	resp, err := c.httpClient.Get(url)
 	if err != nil {
 		return
@@ -321,7 +388,10 @@ func (c *Client) BalanceOf(accid string) (amt *big.Int, err error) {
 }
 
 func (c *Client) StakeOf(accid string) (amt *big.Int, err error) {
-	url := fmt.Sprintf("%s/stakeof/%s", c.baseURL, accid)
+	url, err := c.buildURL("/stakeof/" + accid)
+	if err != nil {
+		return
+	}
 	resp, err := c.httpClient.Get(url)
 	if err != nil {
 		return

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -10,7 +10,7 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/hymatrix/hymx/node/schema"
+	nodeSchema "github.com/hymatrix/hymx/node/schema"
 	serverSchema "github.com/hymatrix/hymx/server/schema"
 	vmmSchema "github.com/hymatrix/hymx/vmm/schema"
 	goarSchema "github.com/permadao/goar/schema"
@@ -32,12 +32,80 @@ func NewClient(hmxURL string) *Client {
 				MaxConnsPerHost:     2000,
 			},
 			Timeout: 30 * time.Second,
+			// Disable automatic redirect handling to support 308 redirect
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
 		},
 	}
 }
 
 func (c *Client) Close() {
 	c.httpClient.CloseIdleConnections()
+}
+
+// handleRedirect handles 308 redirect responses by trying alternative nodes
+func (c *Client) handleRedirect(resp *http.Response, originalReq *http.Request, originalBody []byte) (*http.Response, error) {
+	if resp.StatusCode != 308 {
+		return resp, nil
+	}
+
+	// Read redirect response body
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read redirect response: %w", err)
+	}
+
+	// Parse nodes from response
+	var redirectResp nodeSchema.RedirectError
+	if err := json.Unmarshal(body, &redirectResp); err != nil {
+		return nil, fmt.Errorf("failed to parse redirect response: %w", err)
+	}
+
+	// Try each node in the redirect response
+	for _, node := range redirectResp.Nodes {
+		// Create new request with the same method, path, and body as original
+		newURL := node.URL + originalReq.URL.Path
+		if originalReq.URL.RawQuery != "" {
+			newURL += "?" + originalReq.URL.RawQuery
+		}
+
+		// Create new request with original body
+		newReq, err := http.NewRequest(originalReq.Method, newURL, bytes.NewReader(originalBody))
+		if err != nil {
+			continue // Skip invalid URLs
+		}
+
+		// Copy headers from original request
+		for key, values := range originalReq.Header {
+			for _, value := range values {
+				newReq.Header.Add(key, value)
+			}
+		}
+
+		// Execute request to alternative node
+		newResp, err := c.httpClient.Do(newReq)
+		if err != nil {
+			continue // Try next node
+		}
+
+		// If successful (2xx status), return this response
+		if newResp.StatusCode >= 200 && newResp.StatusCode < 300 {
+			return newResp, nil
+		}
+
+		// If still 308, try next node
+		newResp.Body.Close()
+	}
+
+	// If all nodes failed, return original redirect response
+	return &http.Response{
+		StatusCode: 308,
+		Status:     "308 Permanent Redirect",
+		Body:       io.NopCloser(bytes.NewReader(body)),
+		Header:     resp.Header,
+	}, nil
 }
 
 func (c *Client) Send(itemBin []byte) (res *serverSchema.Response, err error) {
@@ -52,9 +120,19 @@ func (c *Client) Send(itemBin []byte) (res *serverSchema.Response, err error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// Handle 308 redirect
+	resp, err = c.handleRedirect(resp, req, itemBin)
+	if err != nil {
+		return nil, err
+	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		// If it's a 308 redirect that couldn't be resolved, return nil response
+		if resp.StatusCode == 308 {
+			return nil, nil
+		}
 		return nil, fmt.Errorf("invalid server response: %d", resp.StatusCode)
 	}
 
@@ -63,7 +141,7 @@ func (c *Client) Send(itemBin []byte) (res *serverSchema.Response, err error) {
 	return res, err
 }
 
-func (c *Client) Info() (info schema.Info, err error) {
+func (c *Client) Info() (info nodeSchema.Info, err error) {
 	url := fmt.Sprintf("%s/info", c.baseURL)
 	resp, err := c.httpClient.Get(url)
 	if err != nil {

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -66,13 +66,17 @@ func (c *Client) handleRedirect(resp *http.Response, originalReq *http.Request, 
 	// Try each node in the redirect response
 	for _, node := range redirectResp.Nodes {
 		// Create new request with the same method, path, and body as original
-		newURL := node.URL + originalReq.URL.Path
-		if originalReq.URL.RawQuery != "" {
-			newURL += "?" + originalReq.URL.RawQuery
+		newURL, err := url.Parse(node.URL)
+		if err != nil {
+			continue
+		}
+		if newURL.Path == "" || newURL.Path == "/" {
+			newURL.Path = originalReq.URL.Path
+			newURL.RawQuery = originalReq.URL.RawQuery
 		}
 
 		// Create new request with original body
-		newReq, err := http.NewRequest(originalReq.Method, newURL, bytes.NewReader(originalBody))
+		newReq, err := http.NewRequest(originalReq.Method, newURL.String(), bytes.NewReader(originalBody))
 		if err != nil {
 			continue // Skip invalid URLs
 		}
@@ -83,6 +87,11 @@ func (c *Client) handleRedirect(resp *http.Response, originalReq *http.Request, 
 				newReq.Header.Add(key, value)
 			}
 		}
+
+		// Copy other relevant fields from the original request
+		newReq.Host = newURL.Host
+		newReq.URL = newURL
+		newReq.Close = originalReq.Close
 
 		// Execute request to alternative node
 		newResp, err := c.httpClient.Do(newReq)

--- a/sdk/client_send_redirect_test.go
+++ b/sdk/client_send_redirect_test.go
@@ -58,9 +58,14 @@ func TestSendRedirectHandling(t *testing.T) {
 	testData := []byte(`{"test": "data"}`)
 
 	// Call Send method
-	response, err := client.Send(testData)
+	response, redirectedURL, err := client.Send(testData)
 	if err != nil {
 		t.Fatalf("Send failed: %v", err)
+	}
+
+	// Verify redirected URL is set
+	if redirectedURL == "" {
+		t.Errorf("Expected redirected URL to be set, got empty string")
 	}
 
 	// Verify response is not nil
@@ -110,7 +115,7 @@ func TestSendRedirectWithFailedNodes(t *testing.T) {
 	testData := []byte(`{"test": "data"}`)
 
 	// Call Send method
-	response, err := client.Send(testData)
+	response, redirectedURL, err := client.Send(testData)
 
 	// Should not return error, but should get 308 response
 	if err != nil {
@@ -120,6 +125,11 @@ func TestSendRedirectWithFailedNodes(t *testing.T) {
 	// The response should be nil since we can't parse a successful response from 308
 	if response != nil {
 		t.Errorf("Expected nil response when all nodes fail, got %+v", response)
+	}
+
+	// Redirected URL should be empty when all nodes fail
+	if redirectedURL != "" {
+		t.Errorf("Expected empty redirected URL when all nodes fail, got %s", redirectedURL)
 	}
 
 	t.Log("✅ Send method correctly handled failed alternative nodes")
@@ -162,9 +172,14 @@ func TestSendWithoutRedirect(t *testing.T) {
 	testData := []byte(`{"test": "data"}`)
 
 	// Call Send method
-	response, err := client.Send(testData)
+	response, redirectedURL, err := client.Send(testData)
 	if err != nil {
 		t.Fatalf("Send failed: %v", err)
+	}
+
+	// Redirected URL should be empty when no redirect occurs
+	if redirectedURL != "" {
+		t.Errorf("Expected empty redirected URL when no redirect occurs, got %s", redirectedURL)
 	}
 
 	// Verify response is not nil
@@ -227,9 +242,14 @@ func TestSendRedirectPreservesRequestBody(t *testing.T) {
 	testData := []byte(`{"complex": {"nested": "data", "array": [1, 2, 3]}, "message": "test redirect body preservation"}`)
 
 	// Call Send method
-	_, err := client.Send(testData)
+	_, redirectedURL, err := client.Send(testData)
 	if err != nil {
 		t.Fatalf("Send failed: %v", err)
+	}
+
+	// Verify redirected URL is set
+	if redirectedURL == "" {
+		t.Errorf("Expected redirected URL to be set, got empty string")
 	}
 
 	// Verify the request body was preserved

--- a/sdk/client_send_redirect_test.go
+++ b/sdk/client_send_redirect_test.go
@@ -1,0 +1,254 @@
+package sdk
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	nodeSchema "github.com/hymatrix/hymx/node/schema"
+	serverSchema "github.com/hymatrix/hymx/server/schema"
+	registrySchema "github.com/hymatrix/hymx/vmm/core/registry/schema"
+)
+
+// TestSendRedirectHandling tests the Send method's 308 redirect functionality
+func TestSendRedirectHandling(t *testing.T) {
+	// Create a mock successful server (alternative node)
+	successServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify the request method and content type
+		if r.Method != "POST" {
+			t.Errorf("Expected POST method, got %s", r.Method)
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("Expected Content-Type application/json, got %s", r.Header.Get("Content-Type"))
+		}
+
+		// Return a successful response
+		response := serverSchema.Response{
+			Id:      "test-message-id",
+			Message: "success",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer successServer.Close()
+
+	// Create a mock redirect server (main node)
+	redirectServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Return 308 redirect with alternative nodes
+		redirectResp := nodeSchema.RedirectError{
+			Nodes: []registrySchema.Node{
+				{URL: successServer.URL},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(308)
+		json.NewEncoder(w).Encode(redirectResp)
+	}))
+	defer redirectServer.Close()
+
+	// Create client pointing to redirect server
+	client := NewClient(redirectServer.URL)
+
+	// Test data
+	testData := []byte(`{"test": "data"}`)
+
+	// Call Send method
+	response, err := client.Send(testData)
+	if err != nil {
+		t.Fatalf("Send failed: %v", err)
+	}
+
+	// Verify response is not nil
+	if response == nil {
+		t.Fatalf("Expected non-nil response, got nil")
+	}
+
+	// Verify response
+	if response.Id != "test-message-id" {
+		t.Errorf("Expected Id 'test-message-id', got '%s'", response.Id)
+	}
+	if response.Message != "success" {
+		t.Errorf("Expected Message 'success', got '%s'", response.Message)
+	}
+
+	t.Log("✅ Send method successfully handled 308 redirect")
+}
+
+// TestSendRedirectWithFailedNodes tests Send method when all alternative nodes fail
+func TestSendRedirectWithFailedNodes(t *testing.T) {
+	// Create a mock failed server (alternative node)
+	failedServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("Server error"))
+	}))
+	defer failedServer.Close()
+
+	// Create a mock redirect server (main node)
+	redirectServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Return 308 redirect with failed alternative nodes
+		redirectResp := nodeSchema.RedirectError{
+			Nodes: []registrySchema.Node{
+				{URL: failedServer.URL},
+				{URL: "http://invalid-node:9999"},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(308)
+		json.NewEncoder(w).Encode(redirectResp)
+	}))
+	defer redirectServer.Close()
+
+	// Create client pointing to redirect server
+	client := NewClient(redirectServer.URL)
+
+	// Test data
+	testData := []byte(`{"test": "data"}`)
+
+	// Call Send method
+	response, err := client.Send(testData)
+
+	// Should not return error, but should get 308 response
+	if err != nil {
+		t.Fatalf("Send failed unexpectedly: %v", err)
+	}
+
+	// The response should be nil since we can't parse a successful response from 308
+	if response != nil {
+		t.Errorf("Expected nil response when all nodes fail, got %+v", response)
+	}
+
+	t.Log("✅ Send method correctly handled failed alternative nodes")
+}
+
+// TestSendWithoutRedirect tests Send method with normal successful response
+func TestSendWithoutRedirect(t *testing.T) {
+	// Create a mock successful server
+	successServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify request
+		if r.Method != "POST" {
+			t.Errorf("Expected POST method, got %s", r.Method)
+		}
+
+		// Read and verify request body
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("Failed to read request body: %v", err)
+		}
+		expectedBody := `{"test": "data"}`
+		if string(body) != expectedBody {
+			t.Errorf("Expected body '%s', got '%s'", expectedBody, string(body))
+		}
+
+		// Return successful response
+		response := serverSchema.Response{
+			Id:      "direct-message-id",
+			Message: "direct-success",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer successServer.Close()
+
+	// Create client pointing to success server
+	client := NewClient(successServer.URL)
+
+	// Test data
+	testData := []byte(`{"test": "data"}`)
+
+	// Call Send method
+	response, err := client.Send(testData)
+	if err != nil {
+		t.Fatalf("Send failed: %v", err)
+	}
+
+	// Verify response is not nil
+	if response == nil {
+		t.Fatalf("Expected non-nil response, got nil")
+	}
+
+	// Verify response
+	if response.Id != "direct-message-id" {
+		t.Errorf("Expected Id 'direct-message-id', got '%s'", response.Id)
+	}
+	if response.Message != "direct-success" {
+		t.Errorf("Expected Message 'direct-success', got '%s'", response.Message)
+	}
+
+	t.Log("✅ Send method works correctly without redirect")
+}
+
+// TestSendRedirectPreservesRequestBody tests that request body is preserved during redirect
+func TestSendRedirectPreservesRequestBody(t *testing.T) {
+	var receivedBody []byte
+
+	// Create a mock successful server that captures the request body
+	successServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("Failed to read request body: %v", err)
+			return
+		}
+		receivedBody = body
+
+		// Return successful response
+		response := serverSchema.Response{
+			Id:      "body-test-id",
+			Message: "body-preserved",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer successServer.Close()
+
+	// Create a mock redirect server
+	redirectServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		redirectResp := nodeSchema.RedirectError{
+			Nodes: []registrySchema.Node{
+				{URL: successServer.URL},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(308)
+		json.NewEncoder(w).Encode(redirectResp)
+	}))
+	defer redirectServer.Close()
+
+	// Create client
+	client := NewClient(redirectServer.URL)
+
+	// Test with complex JSON data
+	testData := []byte(`{"complex": {"nested": "data", "array": [1, 2, 3]}, "message": "test redirect body preservation"}`)
+
+	// Call Send method
+	_, err := client.Send(testData)
+	if err != nil {
+		t.Fatalf("Send failed: %v", err)
+	}
+
+	// Verify the request body was preserved
+	if !bytes.Equal(receivedBody, testData) {
+		t.Errorf("Request body not preserved during redirect.\nExpected: %s\nReceived: %s", string(testData), string(receivedBody))
+	}
+
+	t.Log("✅ Send method correctly preserves request body during redirect")
+}
+
+func TestMain(m *testing.M) {
+	fmt.Println("🧪 Running SDK Send Method Redirect Tests")
+	fmt.Println("==========================================")
+	result := m.Run()
+	fmt.Println("==========================================")
+	if result == 0 {
+		fmt.Println("✅ All Send redirect tests passed!")
+	} else {
+		fmt.Println("❌ Some tests failed")
+	}
+	fmt.Println()
+}

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -49,7 +49,7 @@ func (s *SDK) GetAddress() string {
 	return s.Bundler.Address
 }
 
-func (s *SDK) Send(processId, data string, tags []goarSchema.Tag) (res *serverSchema.Response, err error) {
+func (s *SDK) Send(processId, data string, tags []goarSchema.Tag) (res *serverSchema.Response, redirectedURL string, err error) {
 	tags = utils.MergeTags([]goarSchema.Tag{
 		{Name: "SDK-Timestamp", Value: fmt.Sprintf("%d", time.Now().UnixNano())},
 	}, tags)
@@ -63,7 +63,7 @@ func (s *SDK) Send(processId, data string, tags []goarSchema.Tag) (res *serverSc
 }
 
 // Send message to process
-func (s *SDK) SendMessage(target, data string, params []goarSchema.Tag) (*serverSchema.Response, error) {
+func (s *SDK) SendMessage(target, data string, params []goarSchema.Tag) (resp *serverSchema.Response, err error) {
 	msg := schema.Message{
 		Base: schema.DefaultBaseMessage,
 	}
@@ -73,11 +73,12 @@ func (s *SDK) SendMessage(target, data string, params []goarSchema.Tag) (*server
 	}
 	// merge params -> tags
 	msgTags = utils.MergeTags(msgTags, params)
-	return s.Send(target, data, msgTags)
+	resp, _, err = s.Send(target, data, msgTags)
+	return
 }
 
 // Spawn for process creation
-func (s *SDK) Spawn(module, scheduler string, params []goarSchema.Tag) (*serverSchema.Response, error) {
+func (s *SDK) Spawn(module, scheduler string, params []goarSchema.Tag) (resp *serverSchema.Response, err error) {
 	process := schema.Process{
 		Base:      schema.DefaultBaseProcess,
 		Module:    module,
@@ -90,7 +91,8 @@ func (s *SDK) Spawn(module, scheduler string, params []goarSchema.Tag) (*serverS
 
 	// merge params -> processTags
 	processTags = utils.MergeTags(processTags, params)
-	return s.Send("", "", processTags)
+	resp, _, err = s.Send("", "", processTags)
+	return
 }
 
 func (s *SDK) GenerateModule(moduleBytes []byte, module schema.Module) (item goarSchema.BundleItem, err error) {

--- a/server/api.go
+++ b/server/api.go
@@ -110,7 +110,6 @@ func (s *Server) Submit(c *gin.Context) {
 
 	err = s.node.Handle(item)
 	if err != nil {
-		log.Error("handle item failed", "err", err)
 		// Check if it's a redirect error
 		if redirectErr, ok := err.(*nodeSchema.RedirectError); ok {
 			// Return 308 Permanent Redirect with Location header and nodes information
@@ -122,6 +121,7 @@ func (s *Server) Submit(c *gin.Context) {
 			c.JSON(http.StatusPermanentRedirect, redirectErr.Nodes)
 			return
 		}
+		log.Error("handle item failed", "err", err)
 		schema.ErrorResponse(c, err.Error())
 		return
 	}

--- a/server/api.go
+++ b/server/api.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/hymatrix/hymx/common"
+	nodeSchema "github.com/hymatrix/hymx/node/schema"
 	"github.com/hymatrix/hymx/server/schema"
 	goarUtils "github.com/permadao/goar/utils"
 )
@@ -110,6 +111,17 @@ func (s *Server) Submit(c *gin.Context) {
 	err = s.node.Handle(item)
 	if err != nil {
 		log.Error("handle item failed", "err", err)
+		// Check if it's a redirect error
+		if redirectErr, ok := err.(*nodeSchema.RedirectError); ok {
+			// Return 308 Permanent Redirect with Location header and nodes information
+			if len(redirectErr.Nodes) > 0 {
+				// Set Location header to the first available node URL for browser auto-redirect
+				c.Header("Location", redirectErr.Nodes[0].URL)
+			}
+			// Also return nodes information in response body for client SDK usage
+			c.JSON(http.StatusPermanentRedirect, redirectErr.Nodes)
+			return
+		}
 		schema.ErrorResponse(c, err.Error())
 		return
 	}

--- a/vmm/apply.go
+++ b/vmm/apply.go
@@ -11,7 +11,7 @@ func (v *Vmm) apply(meta schema.Meta) error {
 	if err != nil {
 		return err
 	}
-
+	log.Debug("===> apply", "meta", meta, "env", env)
 	from, err := v.applyCheck(vm, env, meta)
 	if err != nil {
 		return err
@@ -51,7 +51,6 @@ func (v *Vmm) applyCheck(vm schema.Vm, env *schema.Env, m schema.Meta) (from str
 		return
 	}
 	env.Nonce = m.Nonce
-	log.Debug("===>env", "env", env)
 
 	from = m.AccId
 	if m.FromProcess != "" {


### PR DESCRIPTION
feat(redirect): Implement 308 Permanent Redirect feature and add relevant tests

- Add RedirectError type for handling node redirection
- Update redirect error handling logic in handle.go
- Add 308 redirect response handling in server/api.go
- Implement automatic retry with fallback nodes in sdk/client.go
- Add test files redirect_test.go and client_send_redirect_test.go
- Update examples/main.go to fetch private key from environment variables
- Modify GenesisAccId and URL in default configuration