### PR TITLE
hotfix: sleep schedule to shared schema variable

### DIFF
--- a/node/outbox.go
+++ b/node/outbox.go
@@ -152,11 +152,11 @@ func (n *Node) tryGetLocalAssign(item goarSchema.BundleItem) (assignItem goarSch
 		close(resultChan)
 	}()
 
-	for retry := 0; retry < len(schema.SleepSchedule); retry++ {
+	for retry := 0; retry < len(schema.TryAssignSleepTime); retry++ {
 		log.Debug("outbox try get assign retry", "retry", retry)
 
-		if schema.SleepSchedule[retry] > 0 {
-			time.Sleep(schema.SleepSchedule[retry])
+		if schema.TryAssignSleepTime[retry] > 0 {
+			time.Sleep(schema.TryAssignSleepTime[retry])
 		}
 
 		err = n.Handle(item)
@@ -197,11 +197,11 @@ func (n *Node) tryGetAssign(msgId string, nodes []registrySchema.Node, itemBin [
 		cli = sdk.NewClient(nodes[0].URL)
 	}
 
-	for retry := 0; retry < len(schema.SleepSchedule); retry++ {
+	for retry := 0; retry < len(schema.TryAssignSleepTime); retry++ {
 		cli.Send(itemBin)
 
-		if schema.SleepSchedule[retry] > 0 {
-			time.Sleep(schema.SleepSchedule[retry])
+		if schema.TryAssignSleepTime[retry] > 0 {
+			time.Sleep(schema.TryAssignSleepTime[retry])
 		}
 		assignItem, err = cli.GetAssignByMessage(msgId)
 		if err != nil {

--- a/node/outbox.go
+++ b/node/outbox.go
@@ -152,10 +152,11 @@ func (n *Node) tryGetLocalAssign(item goarSchema.BundleItem) (assignItem goarSch
 		close(resultChan)
 	}()
 
-	for retry := 0; retry < 5; retry++ {
+	for retry := 0; retry < len(schema.SleepSchedule); retry++ {
 		log.Debug("outbox try get assign retry", "retry", retry)
-		if retry > 0 {
-			time.Sleep(100 * time.Millisecond)
+
+		if schema.SleepSchedule[retry] > 0 {
+			time.Sleep(schema.SleepSchedule[retry])
 		}
 
 		err = n.Handle(item)
@@ -196,23 +197,11 @@ func (n *Node) tryGetAssign(msgId string, nodes []registrySchema.Node, itemBin [
 		cli = sdk.NewClient(nodes[0].URL)
 	}
 
-	sleepSchedule := []time.Duration{
-		0,
-		500 * time.Millisecond,
-		1 * time.Second,
-		3 * time.Second,
-		5 * time.Second,
-		10 * time.Second,
-		20 * time.Second,
-		50 * time.Second,
-		80 * time.Second,
-	}
-
-	for retry := 0; retry < len(sleepSchedule); retry++ {
+	for retry := 0; retry < len(schema.SleepSchedule); retry++ {
 		cli.Send(itemBin)
 
-		if sleepSchedule[retry] > 0 {
-			time.Sleep(sleepSchedule[retry])
+		if schema.SleepSchedule[retry] > 0 {
+			time.Sleep(schema.SleepSchedule[retry])
 		}
 		assignItem, err = cli.GetAssignByMessage(msgId)
 		if err != nil {

--- a/node/schema/default.go
+++ b/node/schema/default.go
@@ -1,6 +1,10 @@
 package schema
 
-import "github.com/hymatrix/hymx/vmm/core/registry/schema"
+import (
+	"time"
+
+	"github.com/hymatrix/hymx/vmm/core/registry/schema"
+)
 
 const (
 	NodeVersion  = "v0.2.0"
@@ -16,5 +20,17 @@ var (
 		Desc:  "Test network genesis node",
 		URL:   "https://hymatrix.ai",
 		// URL: "http://127.0.0.1:8080",
+	}
+
+	SleepSchedule = []time.Duration{
+		0,
+		500 * time.Millisecond,
+		1 * time.Second,
+		3 * time.Second,
+		5 * time.Second,
+		10 * time.Second,
+		20 * time.Second,
+		50 * time.Second,
+		80 * time.Second,
 	}
 )

--- a/node/schema/default.go
+++ b/node/schema/default.go
@@ -22,7 +22,7 @@ var (
 		// URL: "http://127.0.0.1:8080",
 	}
 
-	SleepSchedule = []time.Duration{
+	TryAssignSleepTime = []time.Duration{
 		0,
 		500 * time.Millisecond,
 		1 * time.Second,


### PR DESCRIPTION
- Moved the sleep schedule durations to a shared SleepSchedule variable in schema/default.go for reuse and consistency.
- Updated outbox.go to reference schema.SleepSchedule instead of hardcoded values.