### PR TITLE
Optimize GetResult by checking local DB first

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -152,6 +152,12 @@ func (n *Node) GetResult(pid, msgid string) (result *vmmSchema.Result, err error
 		return n.getLocalResult(msgid)
 	}
 
+	// try get from local db first
+	result, err = n.getLocalResult(msgid)
+	if err == nil && result != nil {
+		return
+	}
+
 	// get nodes info, if need redirect
 	isRedirect, nodes, err := n.isRedirect(pid)
 	if err != nil {
@@ -164,6 +170,7 @@ func (n *Node) GetResult(pid, msgid string) (result *vmmSchema.Result, err error
 		return nil, err
 	}
 	// return local result
+
 	return n.getLocalResult(msgid)
 }
 


### PR DESCRIPTION
Added logic to attempt fetching the result from the local database before performing redirect checks or additional lookups. This improves efficiency by returning early if the result is already available locally.