### PR TITLE
Centralize redirect error handling with middleware

### DIFF
--- a/common/middleware.go
+++ b/common/middleware.go
@@ -1,6 +1,11 @@
 package common
 
-import "github.com/gin-gonic/gin"
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	nodeSchema "github.com/hymatrix/hymx/node/schema"
+)
 
 func CORSMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
@@ -16,4 +21,32 @@ func CORSMiddleware() gin.HandlerFunc {
 
 		c.Next()
 	}
+}
+
+// RedirectErrorMiddleware handles redirect errors in a centralized way
+func RedirectErrorMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Next()
+
+		// Check if there's an error in the context
+		if len(c.Errors) > 0 {
+			err := c.Errors.Last().Err
+			if redirectErr, ok := err.(*nodeSchema.RedirectError); ok {
+				// Handle redirect error
+				handleRedirectError(c, redirectErr)
+				return
+			}
+		}
+	}
+}
+
+// handleRedirectError handles redirect errors by setting appropriate headers and response
+func handleRedirectError(c *gin.Context, redirectErr *nodeSchema.RedirectError) {
+	// Return 308 Permanent Redirect with Location header and nodes information
+	if len(redirectErr.Nodes) > 0 {
+		// Set Location header to the first available node URL for browser auto-redirect
+		c.Header("Location", redirectErr.Nodes[0].URL)
+	}
+	// Also return nodes information in response body for client SDK usage
+	c.JSON(http.StatusPermanentRedirect, redirectErr.Nodes)
 }

--- a/node/handle.go
+++ b/node/handle.go
@@ -56,7 +56,13 @@ func (n *Node) Handle(item goarSchema.BundleItem) (err error) {
 	case hymxSchema.Process:
 		// check if scheduler is not node accid
 		if v.Scheduler != n.bundler.Address {
-			err = schema.ErrRedirect
+			// Build redirect info; guard against nil node
+			redirectNodes := []registrySchema.Node{}
+			node, _ := n.vmm.GetNode(v.Scheduler)
+			if node != nil {
+				redirectNodes = append(redirectNodes, *node)
+			}
+			err = schema.NewRedirectError(pid, redirectNodes)
 			log.Warn("handle process failed", "pid", pid, "scheduler", v.Scheduler, "nodeAccId", n.bundler.Address, "err", err)
 			return
 		}

--- a/node/handle.go
+++ b/node/handle.go
@@ -56,13 +56,7 @@ func (n *Node) Handle(item goarSchema.BundleItem) (err error) {
 	case hymxSchema.Process:
 		// check if scheduler is not node accid
 		if v.Scheduler != n.bundler.Address {
-			// Build redirect info; guard against nil node
-			redirectNodes := []registrySchema.Node{}
-			node, _ := n.vmm.GetNode(v.Scheduler)
-			if node != nil {
-				redirectNodes = append(redirectNodes, *node)
-			}
-			err = schema.NewRedirectError(pid, redirectNodes)
+			err = schema.NewSchedulerWrongError(v.Scheduler)
 			log.Warn("handle process failed", "pid", pid, "scheduler", v.Scheduler, "nodeAccId", n.bundler.Address, "err", err)
 			return
 		}
@@ -90,14 +84,14 @@ func (n *Node) Handle(item goarSchema.BundleItem) (err error) {
 		}
 	case hymxSchema.Message:
 		// check if need redirect
-		isRedirect, nodes, e := n.IsRedirect(pid)
+		isRedirect, e := n.IsRedirect(pid)
 		if e != nil {
 			err = e
 			return
 		}
 		if isRedirect {
 			// return nodes with redirect error for 308 redirect
-			err = schema.NewRedirectError(pid, nodes)
+			err = schema.NewRedirectError(pid, nil)
 			log.Warn("message redirect", "pid", pid, "err", err)
 			return
 		}
@@ -170,9 +164,9 @@ func (n *Node) HandleDryRun(item goarSchema.BundleItem, assign hymxSchema.Assign
 	}
 }
 
-func (n *Node) IsRedirect(pid string) (ok bool, nodes []registrySchema.Node, err error) {
+func (n *Node) IsRedirect(pid string) (ok bool, err error) {
 	ok = true
-	nodes, err = n.vmm.GetNodesByProcess(pid)
+	nodes, err := n.vmm.GetNodesByProcess(pid)
 	if err != nil {
 		return
 	}

--- a/node/handle.go
+++ b/node/handle.go
@@ -52,12 +52,6 @@ func (n *Node) Handle(item goarSchema.BundleItem) (err error) {
 		return
 	}
 
-	// get nodes info, if need redirect
-	isRedirect, nodes, err := n.isRedirect(pid)
-	if err != nil {
-		return err
-	}
-
 	switch v := instance.(type) {
 	case hymxSchema.Process:
 		// check if scheduler is not node accid
@@ -67,6 +61,7 @@ func (n *Node) Handle(item goarSchema.BundleItem) (err error) {
 			return
 		}
 		// check if process already register
+		nodes, _ := n.vmm.GetNodesByProcess(pid)
 		if len(nodes) != 0 {
 			err = schema.ErrProcessAlreadyExists
 			log.Error("handle process failed", "pid", pid, "err", err)
@@ -89,16 +84,21 @@ func (n *Node) Handle(item goarSchema.BundleItem) (err error) {
 		}
 	case hymxSchema.Message:
 		// check if need redirect
+		isRedirect, nodes, e := n.IsRedirect(pid)
+		if e != nil {
+			err = e
+			return
+		}
 		if isRedirect {
 			// return nodes with redirect error for 308 redirect
-			err = schema.NewRedirectError(nodes)
+			err = schema.NewRedirectError(pid, nodes)
 			log.Warn("message redirect", "pid", pid, "err", err)
 			return
 		}
 
 		// check if the process not found before assignment
 		if !n.vmm.IsExists(pid) {
-			err = schema.ErrProcessNotFound
+			err = schema.NewProcessNotFoundError(pid)
 			log.Error("handle message failed", "pid", pid, "err", err)
 			return
 		}
@@ -164,7 +164,7 @@ func (n *Node) HandleDryRun(item goarSchema.BundleItem, assign hymxSchema.Assign
 	}
 }
 
-func (n *Node) isRedirect(pid string) (ok bool, nodes []registrySchema.Node, err error) {
+func (n *Node) IsRedirect(pid string) (ok bool, nodes []registrySchema.Node, err error) {
 	ok = true
 	nodes, err = n.vmm.GetNodesByProcess(pid)
 	if err != nil {

--- a/node/node.go
+++ b/node/node.go
@@ -148,30 +148,7 @@ func (n *Node) GetMessage(msgid string) (msg *goarSchema.BundleItem, err error) 
 }
 
 func (n *Node) GetResult(pid, msgid string) (result *vmmSchema.Result, err error) {
-	if n.vmm.RegistryId() == "" {
-		return n.getLocalResult(msgid)
-	}
-
-	// try get from local db first
-	result, err = n.getLocalResult(msgid)
-	if err == nil && result != nil {
-		return
-	}
-
-	// get nodes info, if need redirect
-	isRedirect, nodes, err := n.isRedirect(pid)
-	if err != nil {
-		return nil, err
-	}
-	if isRedirect {
-		// return nodes with redirect error for 308 redirect
-		err = schema.NewRedirectError(nodes)
-		log.Warn("message redirect", "pid", pid, "err", err)
-		return nil, err
-	}
-	// return local result
-
-	return n.getLocalResult(msgid)
+	return n.db.GetResult(msgid)
 }
 
 func (n *Node) GetResults(pid string, limit int64) (results []vmmSchema.Result, err error) {
@@ -277,8 +254,4 @@ func (n *Node) isSelf(node registrySchema.Node) bool {
 		}
 	}
 	return false
-}
-
-func (n *Node) getLocalResult(msgid string) (result *vmmSchema.Result, err error) {
-	return n.db.GetResult(msgid)
 }

--- a/node/redirect_test.go
+++ b/node/redirect_test.go
@@ -32,7 +32,7 @@ func TestRedirectResponse(t *testing.T) {
 	}
 
 	// Create redirect error
-	redirectErr := schema.NewRedirectError(nodes)
+    redirectErr := schema.NewRedirectError("test-pid", nodes)
 
 	// Setup test server
 	gin.SetMode(gin.TestMode)
@@ -70,7 +70,7 @@ func TestRedirectResponse(t *testing.T) {
 // TestEmptyNodesRedirect tests redirect with empty nodes list
 func TestEmptyNodesRedirect(t *testing.T) {
 	// Create redirect error with empty nodes
-	redirectErr := schema.NewRedirectError([]registrySchema.Node{})
+    redirectErr := schema.NewRedirectError("test-pid", []registrySchema.Node{})
 
 	// Setup test server
 	gin.SetMode(gin.TestMode)
@@ -117,7 +117,7 @@ func TestSingleNodeRedirect(t *testing.T) {
 	}
 
 	// Create redirect error
-	redirectErr := schema.NewRedirectError(nodes)
+    redirectErr := schema.NewRedirectError("test-pid", nodes)
 
 	// Setup test server
 	gin.SetMode(gin.TestMode)

--- a/node/schema/errors.go
+++ b/node/schema/errors.go
@@ -2,51 +2,61 @@ package schema
 
 import (
 	"errors"
+
 	registrySchema "github.com/hymatrix/hymx/vmm/core/registry/schema"
 )
 
 var (
-    ErrInvalidType               = errors.New("err_invalid_type")
-    ErrProcessIsRecovering       = errors.New("err_process_is_recovering")
-    ErrProcessAlreadyExists      = errors.New("err_process_already_exist")
-    ErrProcessNotFound           = errors.New("err_process_not_found")
-    ErrRedirect                  = errors.New("err_redirect")
-    ErrDuplicateItem             = errors.New("err_duplicate_item")
-    ErrNotFoundNodes             = errors.New("err_not_found_nodes")
-    ErrNotFoundCkp               = errors.New("err_not_found_ckp")
-    ErrNotFoundMod               = errors.New("err_not_found_mod")
-    ErrUnrecognizedSignatureType = errors.New("err_unrecognized_signature_type")
-    ErrUnauthorizedNode          = errors.New("err_unauthorized_node")
+	ErrInvalidType               = errors.New("err_invalid_type")
+	ErrProcessIsRecovering       = errors.New("err_process_is_recovering")
+	ErrProcessAlreadyExists      = errors.New("err_process_already_exist")
+	ErrProcessNotFound           = errors.New("err_process_not_found")
+	ErrRedirect                  = errors.New("err_redirect")
+	ErrSchedulerWrong            = errors.New("err_scheduler_wrong")
+	ErrDuplicateItem             = errors.New("err_duplicate_item")
+	ErrNotFoundNodes             = errors.New("err_not_found_nodes")
+	ErrNotFoundCkp               = errors.New("err_not_found_ckp")
+	ErrNotFoundMod               = errors.New("err_not_found_mod")
+	ErrUnrecognizedSignatureType = errors.New("err_unrecognized_signature_type")
+	ErrUnauthorizedNode          = errors.New("err_unauthorized_node")
 )
 
 // RedirectError contains nodes information for 308 redirect
 type RedirectError struct {
-    Pid   string                  `json:"pid"`
-    Nodes []registrySchema.Node `json:"nodes"`
+	Pid   string                `json:"pid"`
+	Nodes []registrySchema.Node `json:"nodes"`
 }
 
 func (e *RedirectError) Error() string {
-    return "err_redirect"
+	return "err_redirect"
 }
 
 // NewRedirectError creates a new redirect error with nodes information
 func NewRedirectError(pid string, nodes []registrySchema.Node) *RedirectError {
-    return &RedirectError{Pid: pid, Nodes: nodes}
+	return &RedirectError{Pid: pid, Nodes: nodes}
 }
 
 // ProcessNotFoundError carries pid for better context and unwraps to ErrProcessNotFound
 type ProcessNotFoundError struct {
-    Pid string `json:"pid"`
+	Pid string `json:"pid"`
 }
 
 func (e *ProcessNotFoundError) Error() string {
-    return ErrProcessNotFound.Error()
-}
-
-func (e *ProcessNotFoundError) Unwrap() error {
-    return ErrProcessNotFound
+	return ErrProcessNotFound.Error()
 }
 
 func NewProcessNotFoundError(pid string) *ProcessNotFoundError {
-    return &ProcessNotFoundError{Pid: pid}
+	return &ProcessNotFoundError{Pid: pid}
+}
+
+type SchedulerWrongError struct {
+	Scheduler string `json:"scheduler"`
+}
+
+func (e *SchedulerWrongError) Error() string {
+	return ErrSchedulerWrong.Error()
+}
+
+func NewSchedulerWrongError(scheduler string) *SchedulerWrongError {
+	return &SchedulerWrongError{Scheduler: scheduler}
 }

--- a/node/schema/errors.go
+++ b/node/schema/errors.go
@@ -6,29 +6,47 @@ import (
 )
 
 var (
-	ErrInvalidType               = errors.New("err_invalid_type")
-	ErrProcessIsRecovering       = errors.New("err_process_is_recovering")
-	ErrProcessAlreadyExists      = errors.New("err_process_already_exist")
-	ErrProcessNotFound           = errors.New("err_process_not_found")
-	ErrRedirect                  = errors.New("err_redirect")
-	ErrDuplicateItem             = errors.New("err_duplicate_item")
-	ErrNotFoundNodes             = errors.New("err_not_found_nodes")
-	ErrNotFoundCkp               = errors.New("err_not_found_ckp")
-	ErrNotFoundMod               = errors.New("err_not_found_mod")
-	ErrUnrecognizedSignatureType = errors.New("err_unrecognized_signature_type")
-	ErrUnauthorizedNode          = errors.New("err_unauthorized_node")
+    ErrInvalidType               = errors.New("err_invalid_type")
+    ErrProcessIsRecovering       = errors.New("err_process_is_recovering")
+    ErrProcessAlreadyExists      = errors.New("err_process_already_exist")
+    ErrProcessNotFound           = errors.New("err_process_not_found")
+    ErrRedirect                  = errors.New("err_redirect")
+    ErrDuplicateItem             = errors.New("err_duplicate_item")
+    ErrNotFoundNodes             = errors.New("err_not_found_nodes")
+    ErrNotFoundCkp               = errors.New("err_not_found_ckp")
+    ErrNotFoundMod               = errors.New("err_not_found_mod")
+    ErrUnrecognizedSignatureType = errors.New("err_unrecognized_signature_type")
+    ErrUnauthorizedNode          = errors.New("err_unauthorized_node")
 )
 
 // RedirectError contains nodes information for 308 redirect
 type RedirectError struct {
-	Nodes []registrySchema.Node `json:"nodes"`
+    Pid   string                  `json:"pid"`
+    Nodes []registrySchema.Node `json:"nodes"`
 }
 
 func (e *RedirectError) Error() string {
-	return "err_redirect"
+    return "err_redirect"
 }
 
 // NewRedirectError creates a new redirect error with nodes information
-func NewRedirectError(nodes []registrySchema.Node) *RedirectError {
-	return &RedirectError{Nodes: nodes}
+func NewRedirectError(pid string, nodes []registrySchema.Node) *RedirectError {
+    return &RedirectError{Pid: pid, Nodes: nodes}
+}
+
+// ProcessNotFoundError carries pid for better context and unwraps to ErrProcessNotFound
+type ProcessNotFoundError struct {
+    Pid string `json:"pid"`
+}
+
+func (e *ProcessNotFoundError) Error() string {
+    return ErrProcessNotFound.Error()
+}
+
+func (e *ProcessNotFoundError) Unwrap() error {
+    return ErrProcessNotFound
+}
+
+func NewProcessNotFoundError(pid string) *ProcessNotFoundError {
+    return &ProcessNotFoundError{Pid: pid}
 }

--- a/server/api.go
+++ b/server/api.go
@@ -142,14 +142,11 @@ func (s *Server) GetResult(c *gin.Context) {
 
 	dbResult, err := s.node.GetResult(pid, msgid)
 	if err != nil {
-		// Check if it's a redirect error
-		if _, ok := err.(*nodeSchema.RedirectError); ok {
-			// Add error to gin context for middleware to handle
-			c.Error(err)
+		isRedirect, nodes, _ := s.node.IsRedirect(pid)
+		if isRedirect {
+			c.Error(nodeSchema.NewRedirectError(pid, nodes))
 			return
 		}
-		schema.ErrorResponse(c, err.Error())
-		return
 	}
 	if dbResult == nil {
 		c.JSON(http.StatusOK, nil)

--- a/server/api.go
+++ b/server/api.go
@@ -23,9 +23,8 @@ func (s *Server) runAPI(endpoint string) {
 	engine.GET("/info", s.Info)
 	engine.GET("/callback", s.Callback)
 
-	// api post message
-	engine.POST("/", s.Submit)
-	engine.GET("/result/:pid/:msgid", s.GetResult)
+	engine.POST("/", common.RedirectErrorMiddleware(), s.Submit)
+	engine.GET("/result/:pid/:msgid", common.RedirectErrorMiddleware(), s.GetResult)
 	engine.GET("/results/:pid", s.GetResults)
 
 	// api for get message and assignment by nonce
@@ -122,8 +121,9 @@ func (s *Server) Submit(c *gin.Context) {
 	err = s.node.Handle(item)
 	if err != nil {
 		// Check if it's a redirect error
-		if redirectErr, ok := err.(*nodeSchema.RedirectError); ok {
-			s.handleRedirectError(c, redirectErr)
+		if _, ok := err.(*nodeSchema.RedirectError); ok {
+			// Add error to gin context for middleware to handle
+			c.Error(err)
 			return
 		}
 		log.Error("handle item failed", "err", err)
@@ -143,8 +143,9 @@ func (s *Server) GetResult(c *gin.Context) {
 	dbResult, err := s.node.GetResult(pid, msgid)
 	if err != nil {
 		// Check if it's a redirect error
-		if redirectErr, ok := err.(*nodeSchema.RedirectError); ok {
-			s.handleRedirectError(c, redirectErr)
+		if _, ok := err.(*nodeSchema.RedirectError); ok {
+			// Add error to gin context for middleware to handle
+			c.Error(err)
 			return
 		}
 		schema.ErrorResponse(c, err.Error())
@@ -366,15 +367,4 @@ func (s *Server) TrySend(c *gin.Context) {
 func (s *Server) GetModules(c *gin.Context) {
 	names := s.node.GetModuleNames()
 	c.JSON(http.StatusOK, names)
-}
-
-// handleRedirectError handles redirect errors by setting appropriate headers and response
-func (s *Server) handleRedirectError(c *gin.Context, redirectErr *nodeSchema.RedirectError) {
-	// Return 308 Permanent Redirect with Location header and nodes information
-	if len(redirectErr.Nodes) > 0 {
-		// Set Location header to the first available node URL for browser auto-redirect
-		c.Header("Location", redirectErr.Nodes[0].URL)
-	}
-	// Also return nodes information in response body for client SDK usage
-	c.JSON(http.StatusPermanentRedirect, redirectErr.Nodes)
 }

--- a/server/api.go
+++ b/server/api.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hymatrix/hymx/common"
 	nodeSchema "github.com/hymatrix/hymx/node/schema"
 	"github.com/hymatrix/hymx/server/schema"
+	registrySchema "github.com/hymatrix/hymx/vmm/core/registry/schema"
 	goarUtils "github.com/permadao/goar/utils"
 )
 
@@ -121,11 +122,25 @@ func (s *Server) Submit(c *gin.Context) {
 	err = s.node.Handle(item)
 	if err != nil {
 		// Check if it's a redirect error
-		if _, ok := err.(*nodeSchema.RedirectError); ok {
+		if redirectErr, ok := err.(*nodeSchema.RedirectError); ok {
 			// Add error to gin context for middleware to handle
-			c.Error(err)
+			redirectErr.Nodes, _ = s.node.GetNodesByProcess(redirectErr.Pid)
+			c.Error(redirectErr)
 			return
 		}
+
+		// Check if it's a scheduler wrong error
+		if schedulerErr, ok := err.(*nodeSchema.SchedulerWrongError); ok {
+			scheduler := schedulerErr.Scheduler
+			node, _ := s.node.GetNode(scheduler)
+			redirectNodes := []registrySchema.Node{}
+			if node != nil {
+				redirectNodes = append(redirectNodes, *node)
+			}
+			c.Error(nodeSchema.NewRedirectError("", redirectNodes))
+			return
+		}
+
 		log.Error("handle item failed", "err", err)
 		schema.ErrorResponse(c, err.Error())
 		return
@@ -142,8 +157,9 @@ func (s *Server) GetResult(c *gin.Context) {
 
 	dbResult, err := s.node.GetResult(pid, msgid)
 	if err != nil {
-		isRedirect, nodes, _ := s.node.IsRedirect(pid)
+		isRedirect, _ := s.node.IsRedirect(pid)
 		if isRedirect {
+			nodes, _ := s.node.GetNodesByProcess(pid)
 			c.Error(nodeSchema.NewRedirectError(pid, nodes))
 			return
 		}


### PR DESCRIPTION
Introduces RedirectErrorMiddleware in common/middleware.go to handle redirect errors in a centralized way. Updates server/api.go to use this middleware for relevant routes and removes duplicate error handling logic from the Server struct.