### PR TITLE
Add API endpoint to get module details

### DIFF
--- a/sdk/client.go
+++ b/sdk/client.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	nodeSchema "github.com/hymatrix/hymx/node/schema"
+	hymxSchema "github.com/hymatrix/hymx/schema"
 	serverSchema "github.com/hymatrix/hymx/server/schema"
 	registrySchema "github.com/hymatrix/hymx/vmm/core/registry/schema"
 	vmmSchema "github.com/hymatrix/hymx/vmm/schema"
@@ -428,5 +429,31 @@ func (c *Client) StakeOf(accid string) (amt *big.Int, err error) {
 		return
 	}
 
+	return
+}
+
+func (c *Client) GetModule(moduleId string) (module hymxSchema.Module, err error) {
+	url, err := c.buildURL("/module/" + moduleId)
+	if err != nil {
+		return
+	}
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err = fmt.Errorf("invalid server response: %d", resp.StatusCode)
+		return
+	}
+
+	err = json.NewDecoder(resp.Body).Decode(&module)
 	return
 }

--- a/server/api.go
+++ b/server/api.go
@@ -54,6 +54,8 @@ func (s *Server) runAPI(endpoint string) {
 
 	// get all supported modules
 	engine.GET("/modules", s.GetModules)
+	// get module detail
+	engine.GET("/module/:mid", s.GetModule)
 
 	// inject pay api
 	s.injectPayApi(engine)
@@ -366,6 +368,17 @@ func (s *Server) TrySend(c *gin.Context) {
 func (s *Server) GetModules(c *gin.Context) {
 	names := s.node.GetModuleNames()
 	c.JSON(http.StatusOK, names)
+}
+
+func (s *Server) GetModule(c *gin.Context) {
+	moduleId := c.Param("mid")
+	res, err := s.node.LoadModule(moduleId)
+	if err != nil {
+		schema.ErrorResponse(c, err.Error())
+		return
+	}
+
+	c.JSON(http.StatusOK, res)
 }
 
 // handleRedirectError handles redirect errors by setting appropriate headers and response


### PR DESCRIPTION
Introduces GET /module/:mid endpoint and handler to retrieve details for a specific module by its ID. This complements the existing modules listing endpoint.