### PR TITLE
Fix nil pointer dereference on res.Error in apply

### DIFF
--- a/vmm/apply.go
+++ b/vmm/apply.go
@@ -31,7 +31,9 @@ func (v *Vmm) apply(meta schema.Meta) error {
 		Output:      res.Output,
 		Data:        res.Data,
 		Cache:       res.Cache,
-		Error:       res.Error.Error(),
+	}
+	if res.Error != nil {
+		vmmRes.Error = res.Error.Error()
 	}
 	if meta.PushedFor != "" {
 		vmmRes.PushedFor = meta.PushedFor


### PR DESCRIPTION
Previously, res.Error.Error() was called unconditionally, which could cause a panic if res.Error was nil. This commit adds a nil check before assigning the error message.