### PR TITLE
Add backup functionality to Chainkit and Node

### DIFF
--- a/chainkit/backup.go
+++ b/chainkit/backup.go
@@ -1,0 +1,62 @@
+package chainkit
+
+import "fmt"
+
+func (r *Chainkit) backup() error {
+	r.backupLockMu.Lock()
+	if r.backupRunning {
+		r.backupLockMu.Unlock()
+		return fmt.Errorf("backup is running")
+	}
+	r.backupRunning = true
+	r.backupLockMu.Unlock()
+
+	go func() {
+		defer func() {
+			r.backupLockMu.Lock()
+			r.backupRunning = false
+			r.backupLockMu.Unlock()
+		}()
+
+		log.Info("begin backup all")
+		pids, maxNonce, err := r.nodeDB.GetAllProcess()
+		if err != nil {
+			log.Error("backup get all process failed", "err", err)
+			return
+		}
+
+		for i, pid := range pids {
+			log.Info("backup process begin", "pid", pid, "index", i+1, "total", len(pids), "maxNonce", maxNonce[i])
+			err = r.backupProcess(pid, maxNonce[i])
+			if err != nil {
+				log.Error("backup process failed", "pid", pid, "err", err)
+				return
+			}
+		}
+		log.Info("backup all process end")
+	}()
+
+	return nil
+}
+
+func (r *Chainkit) backupProcess(pid string, maxNonce int64) error {
+	log.Info("backup process ", "pid", pid, "maxNonce", maxNonce)
+	for nonce := int64(0); nonce <= maxNonce; nonce++ {
+		log.Debug(fmt.Sprintf("==> %d/%d", nonce, maxNonce))
+		msg, err := r.nodeDB.GetMessageByNonce(pid, nonce)
+		if err != nil {
+			log.Warn("backup get message by nonce failed", "pid", pid, "nonce", nonce, "err", err)
+			continue
+		}
+		if msg == nil {
+			continue
+		}
+
+		err = r.Upload(*msg)
+		if err != nil {
+			return err
+		}
+	}
+	log.Info("backup process end", "pid", pid, "maxNonce", maxNonce)
+	return nil
+}

--- a/chainkit/chainkit.go
+++ b/chainkit/chainkit.go
@@ -155,6 +155,10 @@ func (c *Chainkit) Query(query string) ([]byte, error) {
 	return c.operator.GraphQL(query)
 }
 
+func (c *Chainkit) GetMaxNonce(scheduler, pid string) (int64, error) {
+	return c.queryMaxNonce(scheduler, pid)
+}
+
 // Backup all processes, include messages and assignment
 func (r *Chainkit) Backup() error {
 	return r.backup()

--- a/chainkit/chainkit.go
+++ b/chainkit/chainkit.go
@@ -155,10 +155,12 @@ func (c *Chainkit) Query(query string) ([]byte, error) {
 	return c.operator.GraphQL(query)
 }
 
+// Backup all processes, include messages and assignment
 func (r *Chainkit) Backup() error {
 	return r.backup()
 }
 
+// Backup on process
 func (r *Chainkit) BackupProcess(pid string, maxNonce int64) error {
 	return r.backupProcess(pid, maxNonce)
 }

--- a/chainkit/chainkit.go
+++ b/chainkit/chainkit.go
@@ -30,6 +30,9 @@ type Chainkit struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 	mu     sync.Mutex // Mutex to prevent concurrent execution
+
+	backupRunning bool
+	backupLockMu  sync.Mutex
 }
 
 func New(config schema.Config) *Chainkit {
@@ -150,4 +153,12 @@ func (c *Chainkit) DownloadByPid(pid string, beginNonce, endNonce int64) (result
 // Execute a GraphQL query
 func (c *Chainkit) Query(query string) ([]byte, error) {
 	return c.operator.GraphQL(query)
+}
+
+func (r *Chainkit) Backup() error {
+	return r.backup()
+}
+
+func (r *Chainkit) BackupProcess(pid string, maxNonce int64) error {
+	return r.backupProcess(pid, maxNonce)
 }

--- a/chainkit/graphql.go
+++ b/chainkit/graphql.go
@@ -121,3 +121,36 @@ func (c *Chainkit) queryBatch(scheduler, pid string, beginNonce, size int64) (as
 
 	return assignIds, txIds, nil
 }
+
+// QueryMaxNonce query the max nonce of a process
+func (c *Chainkit) queryMaxNonce(scheduler, pid string) (int64, error) {
+	query := fmt.Sprintf(schema.QueryMaxNonceTmp, scheduler, pid)
+	log.Debug("queryql", "query", query)
+
+	response, err := c.Query(query)
+	if err != nil {
+		return 0, fmt.Errorf("GraphQL query failed: %w", err)
+	}
+
+	var graphQLResp schema.GraphQLResp
+	if err := json.Unmarshal(response, &graphQLResp); err != nil {
+		return 0, fmt.Errorf("failed to parse GraphQL response: %w", err)
+	}
+
+	if len(graphQLResp.Transactions.Edges) == 0 {
+		return 0, fmt.Errorf("no transaction found for process %s", pid)
+	}
+
+	node := graphQLResp.Transactions.Edges[0].Node
+	for _, tag := range node.Tags {
+		if tag.Name == "Nonce" {
+			nonce, err := strconv.ParseInt(tag.Value, 10, 64)
+			if err != nil {
+				return 0, fmt.Errorf("invalid nonce value: %s", tag.Value)
+			}
+			return nonce, nil
+		}
+	}
+
+	return 0, nil
+}

--- a/chainkit/schema/graphql.go
+++ b/chainkit/schema/graphql.go
@@ -53,3 +53,24 @@ const QueryTmp = `
     }
   }
 }`
+
+const QueryMaxNonceTmp = `
+{
+  transactions(
+    owners: ["%s"]
+    tags: [
+      {name: "Process", values: ["%s"]}
+    ]
+    sort: HEIGHT_DESC
+    first: 1
+  ){
+    edges {
+      node {
+        tags {
+          name
+          value
+        }
+      }
+    }
+  }
+}`

--- a/chainkit/schema/schema.go
+++ b/chainkit/schema/schema.go
@@ -21,8 +21,10 @@ type DownloadResult struct {
 type IDBTool interface {
 	// DB
 	GetMessage(msgid string) (msg *goarSchema.BundleItem, err error)
+	GetMessageByNonce(pid string, nonce int64) (msg *goarSchema.BundleItem, err error)
 	GetAssignByNonce(pid string, nonce int64) (assign *goarSchema.BundleItem, err error)
 	GetResult(msgid string) (result *vmmSchema.VmmResult, err error)
+	GetAllProcess() (pids []string, curNonces []int64, err error)
 }
 
 type IDBChainkit interface {

--- a/cmd/cmds.go
+++ b/cmd/cmds.go
@@ -17,6 +17,7 @@ var (
 		{
 			Name:  "start",
 			Usage: "run server in deamon mode",
+			Flags: flags,
 			Action: func(c *cli.Context) error {
 				configPath := c.String("config")
 				if configPath == "" {
@@ -33,7 +34,7 @@ var (
 				if err != nil {
 					return err
 				}
-				command := exec.Command(path, "--config", c.String("config"))
+				command := exec.Command(path, "--config", c.String("config"), "--mode", c.String("mode"))
 
 				// log
 				logName := fmt.Sprintf("%s_%s_%d.log", schema.DataProtocol, nodeSchema.NodeVersion, time.Now().Unix())

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -16,5 +16,11 @@ var (
 			Aliases: []string{"c", "C"},
 			Usage:   "configure path",
 		},
+		&cli.StringFlag{
+			Name:    "mode",
+			Aliases: []string{"m", "M"},
+			Usage:   "start mode: normal or rebuild",
+			Value:   "normal",
+		},
 	}
 )

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -76,7 +76,8 @@ func run(c *cli.Context) (err error) {
 		return err
 	}
 
-	node := node.New(bundler, redisURL, arweaveURL, hymxURL, nodeInfo, chainkit)
+	startMode := c.String("mode")
+	node := node.New(bundler, redisURL, arweaveURL, hymxURL, nodeInfo, chainkit, startMode)
 
 	s := server.New(node, pay)
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
@@ -47,6 +48,11 @@ func action(c *cli.Context) error {
 		return err
 	}
 
+	startMode := c.String("mode")
+	if startMode != nodeSchema.StartModeNormal && startMode != nodeSchema.StartModeRebuild {
+		return fmt.Errorf("invalid --mode: %s; must be 'normal' or 'rebuild'", startMode)
+	}
+
 	return run(c)
 }
 
@@ -76,7 +82,6 @@ func run(c *cli.Context) (err error) {
 		return err
 	}
 
-	startMode := c.String("mode")
 	node := node.New(bundler, redisURL, arweaveURL, hymxURL, nodeInfo, chainkit)
 
 	s := server.New(node, pay)
@@ -91,7 +96,7 @@ func run(c *cli.Context) (err error) {
 	// ex:
 	// s.AddResultHandler(handlers)
 
-	s.Run(port, startMode)
+	s.Run(port, c.String("mode"))
 
 	log.Info("server is running", "protocol version", schema.Variant, "node version", nodeSchema.NodeVersion, "wallet", bundler.Address, "port", port)
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -77,7 +77,7 @@ func run(c *cli.Context) (err error) {
 	}
 
 	startMode := c.String("mode")
-	node := node.New(bundler, redisURL, arweaveURL, hymxURL, nodeInfo, chainkit, startMode)
+	node := node.New(bundler, redisURL, arweaveURL, hymxURL, nodeInfo, chainkit)
 
 	s := server.New(node, pay)
 
@@ -91,7 +91,7 @@ func run(c *cli.Context) (err error) {
 	// ex:
 	// s.AddResultHandler(handlers)
 
-	s.Run(port)
+	s.Run(port, startMode)
 
 	log.Info("server is running", "protocol version", schema.Variant, "node version", nodeSchema.NodeVersion, "wallet", bundler.Address, "port", port)
 

--- a/node/channel.go
+++ b/node/channel.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"github.com/hymatrix/hymx/node/schema"
+	vmmSchema "github.com/hymatrix/hymx/vmm/schema"
 )
 
 func (n *Node) runMsgChan() {
@@ -28,7 +29,7 @@ func (n *Node) runMsgChan() {
 				continue
 			}
 
-			if err := n.applyMessage(i.Pid, i.AccId, i.Item, i.Message, assign, false, 0); err != nil {
+			if err := n.applyMessage(i.Pid, i.AccId, i.Item, i.Message, assign, vmmSchema.ExecModeNormal, 0); err != nil {
 				log.Error("handle item failed", "pid", i.Pid, "itemId", i.Item.Id, "err", err)
 			}
 
@@ -47,7 +48,7 @@ func (n *Node) runProcChan() {
 
 		case i := <-n.assignProcChan:
 
-			if err := n.applyProcess(i.Pid, i.AccId, i.Item, i.Process, false, 0); err != nil {
+			if err := n.applyProcess(i.Pid, i.AccId, i.Item, i.Process, vmmSchema.ExecModeNormal, 0); err != nil {
 				log.Error("spawn failed", "pid", i.Pid, "itemId", i.Item.Id, "err", err)
 				continue
 			}
@@ -85,7 +86,10 @@ func (n *Node) runResultChan() {
 			}
 			n.resultHandlerLockMu.RUnlock()
 
-			if result.DryRun {
+			// normal mode  => save cache and result
+			// rebuild mode => save cache and result
+			// dryrun mode  => NOT save cache and result
+			if result.Mode == vmmSchema.ExecModeDryRun {
 				continue
 			}
 

--- a/node/channel.go
+++ b/node/channel.go
@@ -86,8 +86,8 @@ func (n *Node) runResultChan() {
 			}
 			n.resultHandlerLockMu.RUnlock()
 
-			// normal mode  => save cache and result
-			// rebuild mode => save cache and result
+			// apply mode  => save cache and result
+			// replay mode => save cache and result
 			// dryrun mode  => NOT save cache and result
 			if result.Mode == vmmSchema.ExecModeDryRun {
 				continue

--- a/node/channel.go
+++ b/node/channel.go
@@ -29,7 +29,7 @@ func (n *Node) runMsgChan() {
 				continue
 			}
 
-			if err := n.applyMessage(i.Pid, i.AccId, i.Item, i.Message, assign, vmmSchema.ExecModeNormal, 0); err != nil {
+			if err := n.applyMessage(i.Pid, i.AccId, i.Item, i.Message, assign, vmmSchema.ExecModeApply, 0); err != nil {
 				log.Error("handle item failed", "pid", i.Pid, "itemId", i.Item.Id, "err", err)
 			}
 
@@ -48,7 +48,7 @@ func (n *Node) runProcChan() {
 
 		case i := <-n.assignProcChan:
 
-			if err := n.applyProcess(i.Pid, i.AccId, i.Item, i.Process, vmmSchema.ExecModeNormal, 0); err != nil {
+			if err := n.applyProcess(i.Pid, i.AccId, i.Item, i.Process, vmmSchema.ExecModeApply, 0); err != nil {
 				log.Error("spawn failed", "pid", i.Pid, "itemId", i.Item.Id, "err", err)
 				continue
 			}

--- a/node/fork.go
+++ b/node/fork.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hymatrix/hymx/node/schema"
 	"github.com/hymatrix/hymx/sdk"
 	"github.com/hymatrix/hymx/utils"
+	vmmSchema "github.com/hymatrix/hymx/vmm/schema"
 )
 
 func (n *Node) runDefaultFork() {
@@ -102,7 +103,7 @@ func (n *Node) runForkProcess(pid, checkpointID string, clients []sdk.Client) {
 				continue
 			}
 
-			if err = n.HandleDryRun(msgItem, assign, -1); err != nil {
+			if err = n.HandleMode(msgItem, assign, vmmSchema.ExecModeDryRun, -1); err != nil {
 				log.Error("fork process is in progress, dry run failed", "pid", pid, "nonce", nonce, "err", err)
 				time.Sleep(delay)
 				continue

--- a/node/fork.go
+++ b/node/fork.go
@@ -9,7 +9,7 @@ import (
 	vmmSchema "github.com/hymatrix/hymx/vmm/schema"
 )
 
-func (n *Node) runDefaultFork() {
+func (n *Node) runDefaultFork(mode vmmSchema.ExecMode) {
 	// fork registry
 	if n.info.Registry != "" {
 		ckpId, err := n.db.GetCheckpointIndex(n.info.Registry)
@@ -17,7 +17,7 @@ func (n *Node) runDefaultFork() {
 			log.Warn("fork registry can not get checkpoint index", "pid", n.info.Registry, "err", err)
 		}
 
-		if err := n.Fork(n.info.Registry, ckpId, n.hymxURL); err != nil {
+		if err := n.Fork(n.info.Registry, ckpId, n.hymxURL, mode); err != nil {
 			log.Error("fork registry failed", "registry", n.info.Registry, "url", n.hymxURL, "err", err)
 		}
 	}
@@ -28,13 +28,13 @@ func (n *Node) runDefaultFork() {
 			log.Warn("fork core token can not get checkpoint index", "pid", n.info.Registry, "err", err)
 		}
 
-		if err := n.Fork(n.info.Token, ckpId, n.hymxURL); err != nil {
+		if err := n.Fork(n.info.Token, ckpId, n.hymxURL, mode); err != nil {
 			log.Error("fork core token failed", "token", n.info.Token, "url", n.hymxURL, "err", err)
 		}
 	}
 }
 
-func (n *Node) Fork(pid, checkpointID, nodeURL string) error {
+func (n *Node) Fork(pid, checkpointID, nodeURL string, mode vmmSchema.ExecMode) error {
 	if n.vmm.IsExists(pid) {
 		log.Error("fork process is already exists", "pid", pid)
 		return schema.ErrProcessAlreadyExists
@@ -59,12 +59,12 @@ func (n *Node) Fork(pid, checkpointID, nodeURL string) error {
 		}
 	}
 
-	go n.runForkProcess(pid, checkpointID, clients)
+	go n.runForkProcess(pid, checkpointID, clients, mode)
 
 	return nil
 }
 
-func (n *Node) runForkProcess(pid, checkpointID string, clients []sdk.Client) {
+func (n *Node) runForkProcess(pid, checkpointID string, clients []sdk.Client, mode vmmSchema.ExecMode) {
 	// init nonce to 0
 	nonce := int64(0)
 
@@ -103,8 +103,8 @@ func (n *Node) runForkProcess(pid, checkpointID string, clients []sdk.Client) {
 				continue
 			}
 
-			if err = n.HandleMode(msgItem, assign, vmmSchema.ExecModeDryRun, -1); err != nil {
-				log.Error("fork process is in progress, dry run failed", "pid", pid, "nonce", nonce, "err", err)
+			if err = n.HandleMode(msgItem, assign, mode, -1); err != nil {
+				log.Error("fork process is in progress, handle mode failed", "pid", pid, "nonce", nonce, "err", err)
 				time.Sleep(delay)
 				continue
 			}

--- a/node/handle.go
+++ b/node/handle.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hymatrix/hymx/sdk"
 	"github.com/hymatrix/hymx/utils"
 	registrySchema "github.com/hymatrix/hymx/vmm/core/registry/schema"
+	vmmSchema "github.com/hymatrix/hymx/vmm/schema"
 	goarSchema "github.com/permadao/goar/schema"
 	goarUtils "github.com/permadao/goar/utils"
 )
@@ -64,6 +65,22 @@ func (n *Node) Handle(item goarSchema.BundleItem) (err error) {
 	return
 }
 
+func (n *Node) HandleMode(item goarSchema.BundleItem, assign hymxSchema.Assignment, mode vmmSchema.ExecMode, maxNonce int64) (err error) {
+	pid, accid, _, instance, err := utils.Decode(item)
+	if err != nil {
+		return
+	}
+
+	switch v := instance.(type) {
+	case hymxSchema.Process:
+		return n.applyProcess(pid, accid, item, v, mode, maxNonce)
+	case hymxSchema.Message:
+		return n.applyMessage(pid, accid, item, v, assign, mode, maxNonce)
+	default:
+		return schema.ErrInvalidType
+	}
+}
+
 // verifyFromProcess verifies the fromProcess authentication
 // It handles both registry process verification and regular node authentication
 func (n *Node) verifyFromProcess(item goarSchema.BundleItem, pid, signer, fromProcess string) error {
@@ -94,22 +111,6 @@ func (n *Node) verifyFromProcess(item goarSchema.BundleItem, pid, signer, fromPr
 	}
 
 	return nil
-}
-
-func (n *Node) HandleDryRun(item goarSchema.BundleItem, assign hymxSchema.Assignment, maxNonce int64) (err error) {
-	pid, accid, _, instance, err := utils.Decode(item)
-	if err != nil {
-		return
-	}
-
-	switch v := instance.(type) {
-	case hymxSchema.Process:
-		return n.applyProcess(pid, accid, item, v, true, maxNonce)
-	case hymxSchema.Message:
-		return n.applyMessage(pid, accid, item, v, assign, true, maxNonce)
-	default:
-		return schema.ErrInvalidType
-	}
 }
 
 func (n *Node) authNode(accid, fromProcess string) (err error) {

--- a/node/message.go
+++ b/node/message.go
@@ -44,7 +44,7 @@ func (n *Node) handleMessage(
 func (n *Node) applyMessage(
 	pid, accid string,
 	item goarSchema.BundleItem, msg hymxSchema.Message,
-	assign hymxSchema.Assignment, dryRun bool, maxNonce int64,
+	assign hymxSchema.Assignment, mode vmmSchema.ExecMode, maxNonce int64,
 ) (err error) {
 	nonce, err := strconv.ParseInt(assign.Nonce, 10, 64)
 	if err != nil {
@@ -80,7 +80,7 @@ func (n *Node) applyMessage(
 		Timestamp:        timestamp,
 		Params:           params,
 		Data:             item.Data,
-		DryRun:           dryRun,
+		Mode:             mode,
 		RecoveryMaxNonce: maxNonce,
 	})
 	return

--- a/node/node.go
+++ b/node/node.go
@@ -2,7 +2,6 @@ package node
 
 import (
 	"context"
-	"errors"
 	"math/big"
 	"strconv"
 	"sync"
@@ -285,18 +284,4 @@ func (n *Node) isSelf(node registrySchema.Node) bool {
 		}
 	}
 	return false
-}
-
-func (n *Node) backup() error {
-	if n.chainkit == nil {
-		log.Error("backup failed, chainkit is nil")
-		return errors.New("chainkit is nil")
-	}
-
-	err := n.chainkit.Backup()
-	if err != nil {
-		log.Error("backup run failed", "err", err)
-	}
-
-	return nil
 }

--- a/node/node.go
+++ b/node/node.go
@@ -58,8 +58,6 @@ type Node struct {
 	chainkit *chainkit.Chainkit
 
 	recoveryTaskPool *ants.Pool
-
-	StartMode string
 }
 
 func New(
@@ -69,7 +67,6 @@ func New(
 	hymxURL string,
 	nodeInfo *schema.Info,
 	chainkit *chainkit.Chainkit,
-	startMode string,
 ) *Node {
 	outboxChan := make(chan vmmSchema.Outbox, 1000)
 	resultChan := make(chan vmmSchema.VmmResult, 1000)
@@ -109,11 +106,10 @@ func New(
 		outboxDB:         cache.NewOutbox(),
 		recoveryTaskPool: taskPool,
 		chainkit:         chainkit,
-		StartMode:        startMode,
 	}
 }
 
-func (n *Node) Run() {
+func (n *Node) Run(startMode string) {
 	if n.chainkit != nil {
 		n.chainkit.Run()
 		n.AddAssignResHandler(n.chainkit.AssignmentHandler)
@@ -126,7 +122,7 @@ func (n *Node) Run() {
 	go n.runAssignmentChan()
 	go n.runOutboxChan()
 
-	switch n.StartMode {
+	switch startMode {
 	case schema.StartModeNormal:
 		go n.runRecovery()
 		n.runJoin()
@@ -134,7 +130,7 @@ func (n *Node) Run() {
 	case schema.StartModeRebuild:
 		go n.runReplay()
 		n.runJoin()
-		n.runDefaultFork(vmmSchema.ExecModeApply)
+		n.runDefaultFork(vmmSchema.ExecModeReplay)
 	default:
 		go n.runRecovery()
 		n.runJoin()

--- a/node/node.go
+++ b/node/node.go
@@ -124,14 +124,17 @@ func (n *Node) Run(startMode string) {
 
 	switch startMode {
 	case schema.StartModeNormal:
+		log.Info("start mode selected", "startMode", startMode)
 		go n.runRecovery()
 		n.runJoin()
 		n.runDefaultFork(vmmSchema.ExecModeDryRun)
 	case schema.StartModeRebuild:
+		log.Info("start mode selected", "startMode", startMode)
 		go n.runReplay()
 		n.runJoin()
 		n.runDefaultFork(vmmSchema.ExecModeReplay)
 	default:
+		log.Warn("invalid start mode, fallback to normal", "startMode", startMode)
 		go n.runRecovery()
 		n.runJoin()
 		n.runDefaultFork(vmmSchema.ExecModeDryRun)

--- a/node/node.go
+++ b/node/node.go
@@ -58,6 +58,8 @@ type Node struct {
 	chainkit *chainkit.Chainkit
 
 	recoveryTaskPool *ants.Pool
+
+	StartMode string
 }
 
 func New(
@@ -67,6 +69,7 @@ func New(
 	hymxURL string,
 	nodeInfo *schema.Info,
 	chainkit *chainkit.Chainkit,
+	startMode string,
 ) *Node {
 	outboxChan := make(chan vmmSchema.Outbox, 1000)
 	resultChan := make(chan vmmSchema.VmmResult, 1000)
@@ -106,6 +109,7 @@ func New(
 		outboxDB:         cache.NewOutbox(),
 		recoveryTaskPool: taskPool,
 		chainkit:         chainkit,
+		StartMode:        startMode,
 	}
 }
 
@@ -121,10 +125,22 @@ func (n *Node) Run() {
 	go n.runResultChan()
 	go n.runAssignmentChan()
 	go n.runOutboxChan()
-	go n.runRecovery()
 
-	n.runJoin()
-	n.runDefaultFork()
+	switch n.StartMode {
+	case schema.StartModeNormal:
+		go n.runRecovery()
+		n.runJoin()
+		n.runDefaultFork(vmmSchema.ExecModeDryRun)
+	case schema.StartModeRebuild:
+		go n.runReplay()
+		n.runJoin()
+		n.runDefaultFork(vmmSchema.ExecModeApply)
+	default:
+		go n.runRecovery()
+		n.runJoin()
+		n.runDefaultFork(vmmSchema.ExecModeDryRun)
+	}
+
 }
 
 func (n *Node) Close() {

--- a/node/node.go
+++ b/node/node.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"context"
+	"errors"
 	"math/big"
 	"strconv"
 	"sync"
@@ -284,4 +285,18 @@ func (n *Node) isSelf(node registrySchema.Node) bool {
 		}
 	}
 	return false
+}
+
+func (n *Node) backup() error {
+	if n.chainkit == nil {
+		log.Error("backup failed, chainkit is nil")
+		return errors.New("chainkit is nil")
+	}
+
+	err := n.chainkit.Backup()
+	if err != nil {
+		log.Error("backup run failed", "err", err)
+	}
+
+	return nil
 }

--- a/node/recovery.go
+++ b/node/recovery.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hymatrix/hymx/node/schema"
 	"github.com/hymatrix/hymx/utils"
+	vmmSchema "github.com/hymatrix/hymx/vmm/schema"
 	goarSchema "github.com/permadao/goar/schema"
 )
 
@@ -90,7 +91,7 @@ func (n *Node) recoveryProcess(pid string, maxNonce int64, ckpId string) error {
 				return err
 			}
 
-			if err = n.HandleDryRun(*msg, assign, maxNonce); err != nil {
+			if err = n.HandleMode(*msg, assign, vmmSchema.ExecModeDryRun, maxNonce); err != nil {
 				log.Error("handle message failed in recover", "nonce", nonce, "err", err)
 				continue
 			}

--- a/node/recovery.go
+++ b/node/recovery.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"errors"
+	"fmt"
 	"sync"
 
 	"github.com/hymatrix/hymx/node/schema"
@@ -34,7 +35,7 @@ func (n *Node) runRecovery() error {
 				log.Error("can not get checkpoint index", "pid", pid, "err", err)
 			}
 
-			if err := n.recoveryProcess(pid, maxNonce, ckpId); err != nil {
+			if err := n.recoveryProcess(pid, maxNonce, ckpId, vmmSchema.ExecModeDryRun); err != nil {
 				log.Error("recovery process error", "pid", pid, "maxNonce", maxNonce, "ckpId", ckpId, "err", err)
 			}
 		})
@@ -51,8 +52,8 @@ func (n *Node) runRecovery() error {
 	return nil
 }
 
-func (n *Node) recoveryProcess(pid string, maxNonce int64, ckpId string) error {
-	log.Debug("recovery process", "pid", pid, "maxNonce", maxNonce, "ckpId", ckpId)
+func (n *Node) recoveryProcess(pid string, maxNonce int64, ckpId string, mode vmmSchema.ExecMode) error {
+	log.Debug("recovery process", "pid", pid, "maxNonce", maxNonce, "ckpId", ckpId, "mode", mode)
 	if n.vmm.IsRecovering(pid) {
 		return schema.ErrProcessIsRecovering
 	}
@@ -91,7 +92,7 @@ func (n *Node) recoveryProcess(pid string, maxNonce int64, ckpId string) error {
 				return err
 			}
 
-			if err = n.HandleMode(*msg, assign, vmmSchema.ExecModeDryRun, maxNonce); err != nil {
+			if err = n.HandleMode(*msg, assign, mode, maxNonce); err != nil {
 				log.Error("handle message failed in recover", "nonce", nonce, "err", err)
 				continue
 			}
@@ -113,6 +114,9 @@ func (n *Node) getMessageAndAssignByNonce(pid string, nonce int64) (msgItem, ass
 	}
 
 	// If either is missing, try to download once
+	if n.chainkit == nil {
+		return nil, nil, fmt.Errorf("chainkit is nil")
+	}
 	result, err := n.chainkit.DownloadByPid(pid, nonce, nonce)
 	if err != nil {
 		return nil, nil, err

--- a/node/replay.go
+++ b/node/replay.go
@@ -1,0 +1,58 @@
+package node
+
+import (
+	"fmt"
+	"sync"
+
+	vmmSchema "github.com/hymatrix/hymx/vmm/schema"
+)
+
+func (n *Node) runReplay() error {
+	allProcessId, err := n.sdk.Client.GetProcesses(n.info.Node.AccId)
+	if err != nil {
+		return err
+	}
+
+	pCount := len(allProcessId)
+	var wg sync.WaitGroup
+	wg.Add(pCount)
+
+	// for each process id, create new vm and start it
+	for i := 0; i < pCount; i++ {
+		pid := allProcessId[i]
+		maxNonce, err := n.getMaxNonce(pid)
+		if err != nil {
+			return err
+		}
+
+		err = n.recoveryTaskPool.Submit(func() {
+			defer wg.Done()
+
+			ckpId, err := n.db.GetCheckpointIndex(pid)
+			if err != nil {
+				log.Error("can not get checkpoint index", "pid", pid, "err", err)
+			}
+
+			if err := n.recoveryProcess(pid, maxNonce, ckpId, vmmSchema.ExecModeReplay); err != nil {
+				log.Error("replay process error", "pid", pid, "maxNonce", maxNonce, "ckpId", ckpId, "err", err)
+			}
+		})
+		if err != nil {
+			log.Error("submit replay task error", "pid", pid, "maxNonce", maxNonce, "err", err)
+		}
+	}
+
+	// wait all process recoverd
+	wg.Wait()
+
+	// finish replay
+	log.Info("replay node successfully!")
+	return nil
+}
+
+func (n *Node) getMaxNonce(pid string) (nonce int64, err error) {
+	if n.chainkit == nil {
+		return 0, fmt.Errorf("chainkit is nil")
+	}
+	return n.chainkit.GetMaxNonce(n.info.Node.AccId, pid)
+}

--- a/node/schema/schema.go
+++ b/node/schema/schema.go
@@ -7,6 +7,11 @@ import (
 	goarSchema "github.com/permadao/goar/schema"
 )
 
+const (
+	StartModeNormal  = "normal"
+	StartModeRebuild = "rebuild"
+)
+
 type Info struct {
 	Protocol    string              `json:"Protocol"`
 	Variant     string              `json:"Variant"`

--- a/node/spawn.go
+++ b/node/spawn.go
@@ -56,7 +56,7 @@ func (n *Node) handleProcess(
 func (n *Node) applyProcess(
 	pid, accid string,
 	item goarSchema.BundleItem, proc hymxSchema.Process,
-	dryRun bool, maxNonce int64,
+	mode vmmSchema.ExecMode, maxNonce int64,
 ) (err error) {
 	params, err := utils.TagsToParams(proc.Tags)
 	if err != nil {
@@ -72,7 +72,7 @@ func (n *Node) applyProcess(
 		Timestamp:        0, // ues 0 now. todo: use assignment timestamp
 		Params:           params,
 		Data:             item.Data,
-		DryRun:           dryRun,
+		Mode:             mode,
 		RecoveryMaxNonce: maxNonce,
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -26,7 +26,7 @@ func New(node *node.Node, pay *pay.Pay) *Server {
 	}
 }
 
-func (s *Server) Run(endpoint string) {
+func (s *Server) Run(endpoint string, startMode string) {
 	if s.pay != nil {
 		s.pay.LoadCheckpoint()
 		s.pay.Run()
@@ -36,7 +36,7 @@ func (s *Server) Run(endpoint string) {
 
 	go s.runAPI(endpoint)
 
-	s.node.Run()
+	s.node.Run(startMode)
 }
 
 func (s *Server) Close() {

--- a/vmm/apply.go
+++ b/vmm/apply.go
@@ -28,7 +28,7 @@ func (v *Vmm) apply(meta schema.Meta) error {
 		// send message outbox
 		v.outbox(env, &vmmRes)
 		// recovery unlock
-		if meta.Mode != schema.ExecModeNormal && meta.Nonce == meta.RecoveryMaxNonce {
+		if meta.Mode != schema.ExecModeApply && meta.Nonce == meta.RecoveryMaxNonce {
 			v.RecoveryUnlock(meta.Pid)
 		}
 	}()

--- a/vmm/apply.go
+++ b/vmm/apply.go
@@ -19,7 +19,7 @@ func (v *Vmm) apply(meta schema.Meta) error {
 		ItemId:      meta.ItemId,
 		FromProcess: meta.Pid,
 		PushedFor:   meta.ItemId,
-		DryRun:      meta.DryRun,
+		Mode:        meta.Mode,
 	}
 	if meta.PushedFor != "" {
 		vmmRes.PushedFor = meta.PushedFor
@@ -28,7 +28,7 @@ func (v *Vmm) apply(meta schema.Meta) error {
 		// send message outbox
 		v.outbox(env, &vmmRes)
 		// recovery unlock
-		if meta.DryRun && meta.Nonce == meta.RecoveryMaxNonce {
+		if meta.Mode != schema.ExecModeNormal && meta.Nonce == meta.RecoveryMaxNonce {
 			v.RecoveryUnlock(meta.Pid)
 		}
 	}()

--- a/vmm/outbox.go
+++ b/vmm/outbox.go
@@ -22,7 +22,7 @@ func (v *Vmm) outbox(env *schema.Env, result *schema.VmmResult) {
 		msg.Sequence = fmt.Sprintf("%d", env.Sequence)
 		v.vmsLockMu.Unlock()
 
-		if result.Mode != schema.ExecModeNormal {
+		if result.Mode != schema.ExecModeApply {
 			continue
 		}
 
@@ -57,7 +57,7 @@ func (v *Vmm) outbox(env *schema.Env, result *schema.VmmResult) {
 		spawn.Sequence = fmt.Sprintf("%d", env.Sequence)
 		v.vmsLockMu.Unlock()
 
-		if result.Mode != schema.ExecModeNormal {
+		if result.Mode != schema.ExecModeApply {
 			continue
 		}
 

--- a/vmm/outbox.go
+++ b/vmm/outbox.go
@@ -22,7 +22,7 @@ func (v *Vmm) outbox(env *schema.Env, result *schema.VmmResult) {
 		msg.Sequence = fmt.Sprintf("%d", env.Sequence)
 		v.vmsLockMu.Unlock()
 
-		if result.DryRun {
+		if result.Mode != schema.ExecModeNormal {
 			continue
 		}
 
@@ -57,7 +57,7 @@ func (v *Vmm) outbox(env *schema.Env, result *schema.VmmResult) {
 		spawn.Sequence = fmt.Sprintf("%d", env.Sequence)
 		v.vmsLockMu.Unlock()
 
-		if result.DryRun {
+		if result.Mode != schema.ExecModeNormal {
 			continue
 		}
 

--- a/vmm/registry.go
+++ b/vmm/registry.go
@@ -52,7 +52,7 @@ func (v *Vmm) spawnRegistry(env schema.Env) (vm schema.Vm, err error) {
 		return nil, schema.ErrMissingParam
 	}
 
-	if !env.Meta.DryRun {
+	if env.Meta.Mode == schema.ExecModeNormal {
 		v.info.Node.Role = registrySchema.RoleMain
 		v.info.JoinNetwork = true
 	}

--- a/vmm/registry.go
+++ b/vmm/registry.go
@@ -52,7 +52,7 @@ func (v *Vmm) spawnRegistry(env schema.Env) (vm schema.Vm, err error) {
 		return nil, schema.ErrMissingParam
 	}
 
-	if env.Meta.Mode == schema.ExecModeNormal {
+	if env.Meta.Mode == schema.ExecModeApply {
 		v.info.Node.Role = registrySchema.RoleMain
 		v.info.JoinNetwork = true
 	}

--- a/vmm/schema/schema.go
+++ b/vmm/schema/schema.go
@@ -13,6 +13,21 @@ const (
 	AccountTypeEVM = "evm"
 )
 
+// ExecMode defines the execution behavior of the VMM.
+//
+// | Mode             | Execute | Persist | Outbox |
+// |------------------|---------|---------|--------|
+// | ExecModeNormal   | Yes     | Yes     | Yes    |
+// | ExecModeRebuild  | Yes     | Yes     | No     |
+// | ExecModeDryRun   | Yes     | No      | No     |
+type ExecMode string
+
+const (
+	ExecModeNormal  ExecMode = "normal"
+	ExecModeRebuild ExecMode = "rebuild"
+	ExecModeDryRun  ExecMode = "dryrun"
+)
+
 type VmSpawnFunc func(Env) (Vm, error)
 
 type Vm interface {
@@ -39,8 +54,8 @@ type Meta struct {
 	Params map[string]string `json:"Params"`
 	Data   string            `json:"Data"`
 
-	DryRun           bool  `json:"-"`
-	RecoveryMaxNonce int64 `json:"-"`
+	Mode             ExecMode `json:"-"`
+	RecoveryMaxNonce int64    `json:"-"`
 }
 
 type Result struct {
@@ -90,7 +105,7 @@ type VmmResult struct {
 	Output      interface{}       `json:"Output"`
 	Data        string            `json:"Data"`
 	Cache       map[string]string `json:"Cache,omitempty"`
-	DryRun      bool              `json:"-"`
+	Mode        ExecMode          `json:"-"`
 	Error       string            `json:"Error"`
 }
 

--- a/vmm/schema/schema.go
+++ b/vmm/schema/schema.go
@@ -17,15 +17,15 @@ const (
 //
 // | Mode             | Execute | Persist | Outbox |
 // |------------------|---------|---------|--------|
-// | ExecModeNormal   | Yes     | Yes     | Yes    |
-// | ExecModeRebuild  | Yes     | Yes     | No     |
+// | ExecModeApply   | Yes     | Yes     | Yes    |
+// | ExecModeReplay  | Yes     | Yes     | No     |
 // | ExecModeDryRun   | Yes     | No      | No     |
 type ExecMode string
 
 const (
-	ExecModeNormal  ExecMode = "normal"
-	ExecModeRebuild ExecMode = "rebuild"
-	ExecModeDryRun  ExecMode = "dryrun"
+	ExecModeApply  ExecMode = "apply"
+	ExecModeReplay ExecMode = "replay"
+	ExecModeDryRun ExecMode = "dryrun"
 )
 
 type VmSpawnFunc func(Env) (Vm, error)

--- a/vmm/spawn.go
+++ b/vmm/spawn.go
@@ -33,10 +33,10 @@ func (v *Vmm) Spawn(meta schema.Meta, process hySchema.Process, module hySchema.
 	v.addVm(vm, env)
 
 	result := v.genSpawnResult(env)
-	result.DryRun = meta.DryRun
+	result.Mode = meta.Mode
 	// send to outbox
 	v.outbox(env, result)
-	if meta.DryRun && meta.Nonce == meta.RecoveryMaxNonce {
+	if meta.Mode != schema.ExecModeNormal && meta.Nonce == meta.RecoveryMaxNonce {
 		v.RecoveryUnlock(meta.Pid)
 	}
 

--- a/vmm/spawn.go
+++ b/vmm/spawn.go
@@ -36,7 +36,7 @@ func (v *Vmm) Spawn(meta schema.Meta, process hySchema.Process, module hySchema.
 	result.Mode = meta.Mode
 	// send to outbox
 	v.outbox(env, result)
-	if meta.Mode != schema.ExecModeNormal && meta.Nonce == meta.RecoveryMaxNonce {
+	if meta.Mode != schema.ExecModeApply && meta.Nonce == meta.RecoveryMaxNonce {
 		v.RecoveryUnlock(meta.Pid)
 	}
 


### PR DESCRIPTION
Introduced backup and backupProcess methods to Chainkit, including concurrency control and process iteration. Exposed Backup and BackupProcess methods in Chainkit's public API. Updated schema interfaces to support backup operations. Added backup method to Node to trigger Chainkit backups.