### PR TITLE
Use meta.Nonce when building VmmResult

### DIFF
--- a/vmm/apply.go
+++ b/vmm/apply.go
@@ -14,7 +14,7 @@ func (v *Vmm) apply(meta schema.Meta) error {
 	log.Debug("===> apply", "meta", meta, "env", env)
 
 	vmmRes := schema.VmmResult{
-		Nonce:       fmt.Sprintf("%d", env.Nonce),
+		Nonce:       fmt.Sprintf("%d", meta.Nonce),
 		Timestamp:   fmt.Sprintf("%d", meta.Timestamp),
 		ItemId:      meta.ItemId,
 		FromProcess: meta.Pid,


### PR DESCRIPTION
Fix a bug in Vmm.apply where the VmmResult nonce was populated from env.Nonce. The code now uses meta.Nonce so the result reflects the metadata's nonce value, preventing incorrect/non-matching nonces in the applied result.