### PR TITLE
Sync registry spawn and require registry on spawn

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -58,6 +58,7 @@ type Node struct {
 	chainkit *chainkit.Chainkit
 
 	recoveryTaskPool *ants.Pool
+	registrySpawned  chan struct{}
 }
 
 func New(
@@ -70,6 +71,7 @@ func New(
 ) *Node {
 	outboxChan := make(chan vmmSchema.Outbox, 1000)
 	resultChan := make(chan vmmSchema.VmmResult, 1000)
+	registryCh := make(chan struct{}, 1)
 
 	taskPool, err := ants.NewPool(1000)
 	if err != nil {
@@ -85,7 +87,7 @@ func New(
 		bundler: bundler,
 		sdk:     sdk.NewFromBundler(hymxURL, bundler),
 
-		vmm: vmm.New(nodeInfo, resultChan, outboxChan),
+		vmm: vmm.New(nodeInfo, resultChan, outboxChan, registryCh),
 
 		ctx:    ctx,
 		cancel: cancel,
@@ -106,6 +108,7 @@ func New(
 		outboxDB:         cache.NewOutbox(),
 		recoveryTaskPool: taskPool,
 		chainkit:         chainkit,
+		registrySpawned:  registryCh,
 	}
 }
 
@@ -122,28 +125,26 @@ func (n *Node) Run(startMode string) {
 	go n.runAssignmentChan()
 	go n.runOutboxChan()
 
+	if n.info.Node.Role == registrySchema.RoleMain && startMode == schema.StartModeRebuild {
+		n.runDefaultFork(vmmSchema.ExecModeReplay)
+	} else {
+		n.runDefaultFork(vmmSchema.ExecModeDryRun)
+	}
+
+	n.waitRegistrySpawned()
+
 	switch startMode {
 	case schema.StartModeNormal:
 		log.Info("start mode selected", "startMode", startMode)
 		go n.runRecovery()
-		n.runJoin()
-		n.runDefaultFork(vmmSchema.ExecModeDryRun)
 	case schema.StartModeRebuild:
 		log.Info("start mode selected", "startMode", startMode)
 		go n.runReplay()
-		n.runJoin()
-		if n.info.Node.Role == registrySchema.RoleMain {
-			n.runDefaultFork(vmmSchema.ExecModeReplay) // main node -> replay
-		} else {
-			n.runDefaultFork(vmmSchema.ExecModeDryRun) // other node -> dryrun
-		}
 	default:
 		log.Warn("invalid start mode, fallback to normal", "startMode", startMode)
 		go n.runRecovery()
-		n.runJoin()
-		n.runDefaultFork(vmmSchema.ExecModeDryRun)
 	}
-
+	n.runJoin()
 }
 
 func (n *Node) Close() {
@@ -307,4 +308,12 @@ func (n *Node) isSelf(node registrySchema.Node) bool {
 		}
 	}
 	return false
+}
+
+func (n *Node) waitRegistrySpawned() {
+	if n.vmm.RegistryId() == "" {
+		return
+	}
+	// wait for registry spawned
+	<-n.registrySpawned
 }

--- a/node/node.go
+++ b/node/node.go
@@ -133,15 +133,11 @@ func (n *Node) Run(startMode string) {
 
 	n.waitRegistrySpawned()
 
-	switch startMode {
-	case schema.StartModeNormal:
-		log.Info("start mode selected", "startMode", startMode)
-		go n.runRecovery()
-	case schema.StartModeRebuild:
+	if startMode == schema.StartModeRebuild {
 		log.Info("start mode selected", "startMode", startMode)
 		go n.runReplay()
-	default:
-		log.Warn("invalid start mode, fallback to normal", "startMode", startMode)
+	} else {
+		log.Info("start mode selected", "startMode", startMode)
 		go n.runRecovery()
 	}
 	n.runJoin()
@@ -311,7 +307,7 @@ func (n *Node) isSelf(node registrySchema.Node) bool {
 }
 
 func (n *Node) waitRegistrySpawned() {
-	if n.vmm.RegistryId() == "" {
+	if n.vmm.RegistryId() != "" {
 		return
 	}
 	// wait for registry spawned

--- a/vmm/registry.go
+++ b/vmm/registry.go
@@ -78,6 +78,10 @@ func (v *Vmm) spawnRegistry(env schema.Env) (vm schema.Vm, err error) {
 			"Acc-Id": env.Meta.AccId,
 		}})
 
+	if v.registrySpawned != nil {
+		close(v.registrySpawned)
+	}
+
 	return regVm, nil
 }
 

--- a/vmm/schema/errors.go
+++ b/vmm/schema/errors.go
@@ -12,7 +12,7 @@ var (
 	ErrProcessAlreadyExists   = errors.New("err_process_already_exist")
 	ErrProcessNotFound        = errors.New("err_process_not_found")
 	ErrProcessEnvNotFound     = errors.New("err_process_env_not_found")
-	ErrRegistryNotNound       = errors.New("err_registry_not_found")
+	ErrRegistryNotFound       = errors.New("err_registry_not_found")
 	ErrMissingParam           = errors.New("err_missing_param")
 	ErrInvalidAccid           = errors.New("err_invalid_accid")
 	ErrFactoryAlreadyMounted  = errors.New("err_factory_already_mounted")

--- a/vmm/spawn.go
+++ b/vmm/spawn.go
@@ -16,6 +16,9 @@ func (v *Vmm) Spawn(meta schema.Meta, process hySchema.Process, module hySchema.
 	if v.IsExists(pid) {
 		return schema.ErrProcessAlreadyExists
 	}
+	if v.registry == nil && module.ModuleFormat != schema.ModuleFormatRegistry && module.ModuleFormat != schema.ModuleFormatToken {
+		return schema.ErrRegistryNotFound
+	}
 
 	env := &schema.Env{
 		Meta:        meta,

--- a/vmm/vmm.go
+++ b/vmm/vmm.go
@@ -30,13 +30,14 @@ type Vmm struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 
-	resultChan chan<- schema.VmmResult
-	outboxChan chan<- schema.Outbox
-	applyChan  chan schema.Meta
-	ckpChan    chan schema.Checkpoint
+	resultChan      chan<- schema.VmmResult
+	outboxChan      chan<- schema.Outbox
+	applyChan       chan schema.Meta
+	ckpChan         chan schema.Checkpoint
+	registrySpawned chan struct{}
 }
 
-func New(info *nodeSchema.Info, resultChan chan<- schema.VmmResult, outboxChan chan<- schema.Outbox) *Vmm {
+func New(info *nodeSchema.Info, resultChan chan<- schema.VmmResult, outboxChan chan<- schema.Outbox, registrySpawned chan struct{}) *Vmm {
 	ctx, cancel := context.WithCancel(context.Background())
 	return &Vmm{
 		info: info,
@@ -50,10 +51,11 @@ func New(info *nodeSchema.Info, resultChan chan<- schema.VmmResult, outboxChan c
 		ctx:    ctx,
 		cancel: cancel,
 
-		resultChan: resultChan,
-		outboxChan: outboxChan,
-		applyChan:  make(chan schema.Meta, 1000),
-		ckpChan:    make(chan schema.Checkpoint, 100),
+		resultChan:      resultChan,
+		outboxChan:      outboxChan,
+		applyChan:       make(chan schema.Meta, 1000),
+		ckpChan:         make(chan schema.Checkpoint, 100),
+		registrySpawned: registrySpawned,
 	}
 }
 


### PR DESCRIPTION
- Wire a registrySpawned channel through Node and Vmm to coordinate registry creation: Vmm now signals (close) when registry VM is spawned and Node waits for that signal before proceeding. 

- Add a nil-check in Vmm.Spawn to return ErrRegistryNotFound if no registry is mounted (except when spawning registry/token modules). 

- Fix typo in error name (ErrRegistryNotFound) and adjust field formatting for Vmm/Node constructors. 
 
These changes ensure nodes don't join/operate before the registry is available and surface a clear error when spawning non-registry modules without a registry.